### PR TITLE
[Feature #157185472] Add deployment workflow scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,14 @@
 # Python CircleCI 2.0 configuration file
 
+defaults: &defaults
+  docker:
+    - image: circleci/python:3.6.1
+  working_directory: ~/andela-societies-backend
+
 version: 2
 jobs:
-  build:
-    docker:
-      - image: circleci/python:3.6.1
-    working_directory: ~/andela-societies-backend
-
+  test:
+    <<: *defaults
     steps:
       - checkout
       - setup_remote_docker
@@ -18,3 +20,28 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
+
+  deploy:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 17.11.0-ce
+      - run:
+          name: deploy application
+          command: |
+            bash scripts/deploy.sh
+
+workflows:
+  version: 2
+  test_and_deploy:
+    jobs:
+      - test
+      - deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - staging
+                - master

--- a/docker/release/docker-compose.yml
+++ b/docker/release/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     links:
       - database
     environment:
-      APP_SETTINGS: Production
+      APP_SETTINGS: Staging
       DATABASE_URL: postgresql://soc:soc@database:5432/db
     env_file:
       - ../../src/.env

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+COMMIT_HASH=$(git rev-parse --short HEAD)
+
+if [ "$CIRCLE_BRANCH" == 'master' ]; then
+    IMAGE_TAG=$COMMIT_HASH
+else
+    IMAGE_TAG="${CIRCLE_BRANCH}-${COMMIT_HASH}"
+fi
+
+echo "====> Store Sand authenticate with service account"
+echo $GCLOUD_SERVICE_KEY | base64 --decode > ${HOME}/gcloud-service-key.json
+
+echo "====> Login to docker registry"
+
+docker login -u _json_key --password-stdin https://gcr.io < ${HOME}/gcloud-service-key.json
+
+make release
+
+make tag $IMAGE_TAG
+
+make publish
+
+# TODO: deploy built image to kubernetes cluster


### PR DESCRIPTION
## Resolves #<issue number>
  - #157185472

## Description (what problem you're fixing)

  - Update the CircleCI pipeline to include build, release, tag, publish. When this changes are merged to staging or master branch, CircleCI will build the application, if the tests pass, the application will be tagged and pushed to google container registry.

## Fix (what you did to fix it)

  - Currently building and tagging of images workflow is not present in CircleCi, it is being done manually.

## How to test (describe how to test your PR)

  - This Changes makes use of CircleCI workflow which are not supported by local builds. This changes can only be tested in CircleCI platform.
  
