### PR TITLE
#157349463 Fix authorization error on docker and modify script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test:env_file
 	@ docker-compose -p $(DOCKER_TEST_PROJECT) -f $(DOCKER_TEST_COMPOSE_FILE) down -v
 
 ## Build project image
-release:
+release:env_file
 	${INFO} "Building required container image for the application"
 	@ echo " "
 	@ docker-compose -p $(DOCKER_REL_PROJECT) -f $(DOCKER_REL_COMPOSE_FILE) build app


### PR DESCRIPTION
## Resolves [#157349463](https://www.pivotaltracker.com/story/show/157349463)

## Description (what problem you're fixing)
  - Failed authorization of docker to enable a docker image push to GCP.
  - Script passing even if error exists.

## Fix (what you did to fix it)

  - Modified the arguments on the docker command to arguments that suit the version being used on circle C.I.
  - Modified the script to exit on an error or if the pipe fails

## How to test (describe how to test your PR)

  - Push a commit from the branch called **staging** The push should trigger a deployment build on Circle CI. It is expected that the build will pass and a docker image of the application will be pushed to GCP. Login to the GCP account and view the image that has been pushed under Container Registry.
  
