### PR TITLE
Staging Deployment Pipeline

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,13 +2,19 @@
 set -o errexit
 set -o pipefail
 
-tag_branch() {
+set_variables() {
     COMMIT_HASH=$(git rev-parse --short HEAD)
 
     if [ "$CIRCLE_BRANCH" == 'master' ]; then
         IMAGE_TAG=$COMMIT_HASH
+        ENVIRONMENT=production
+        GOOGLE_COMPUTE_ZONE=${PRODUCTION_ZONE}
+        GOOGLE_CLUSTER_NAME=${PRODUCTION_CLUSTER_NAME}
     else
         IMAGE_TAG="${CIRCLE_BRANCH}-${COMMIT_HASH}"
+        ENVIRONMENT=staging
+        GOOGLE_COMPUTE_ZONE=${STAGING_ZONE}
+        GOOGLE_CLUSTER_NAME=${STAGING_CLUSTER_NAME}
     fi
 }
 
@@ -30,10 +36,46 @@ deploy_image() {
     make publish
 }
 
+install_google_cloud_sdk(){
+    echo "====> Installing google cloud sdk"
+    echo "deb http://packages.cloud.google.com/apt cloud-sdk-jessie main" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+    sudo apt-get update && sudo apt-get install kubectl google-cloud-sdk
+}
+
+configure_google_cloud_sdk() {
+    echo "Configuring Google Cloud Sdk"
+    gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+    gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+    gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+    gcloud --quiet container clusters get-credentials ${GOOGLE_CLUSTER_NAME}
+}
+
+deploy_to_kubernetes(){
+     echo "====> Prepare image for deployement"
+
+    IMAGE="${DOCKER_REGISTRY}/${GOOGLE_PROJECT_ID}/${PROJECT_NAME}:${IMAGE_TAG}"
+    DEPLOYMENT_NAME="${ENVIRONMENT}-${PROJECT_NAME}"
+    echo "====> Deploying ${IMAGE} to ${DEPLOYMENT_NAME} in ${ENVIRONMENT} environment"
+
+
+    kubectl set image deployment/${DEPLOYMENT_NAME} backend=${IMAGE} -n "${ENVIRONMENT}"
+
+    if [ "$?" == "0" ]; then
+        echo "Deployment completed succesfully"
+    else
+        echo "Failed to deploy ${IMAGE} to ${ENVIRONMENT} environment"
+    fi
+
+}
+
 main() {
-    tag_branch
+    set_variables
     authorize_docker
     deploy_image
+    install_google_cloud_sdk
+    configure_google_cloud_sdk
+    deploy_to_kubernetes
 }
 
 main "$@"


### PR DESCRIPTION

## Resolves #157804399

## Description (what problem you're fixing)

  - Find a means whereby the image on which the backend application is running on can be updated automatically rather than manually.

## Fix (what you did to fix it)

  - Added a script that sets the image, which the deployment on the GCP kubernetes cluster is running on, for this application.
  - The script simply authorizes gcloud and kubectl to connect to the specific kubernetes cluster on GCP. Currently at the making of this P.R the staging or production kubernetes cluster.  
  - We then specify a change to the image by using the kubectl set image command. 
 
## How to test (describe how to test your PR)

  - Merge changes to the staging branch from the develop branch and see the build output on circle C.I. (**Note:** If testing on a fork, some environment variables will need to be added on the Circle CI environment variables of the project.)
  - A successful build should indicate that the image has been updated on the build.
  - If you have access you can also visit the GCP page to confirm the image on which the deployment is using. The image should have the first seven letters of the last commit number and the prefix staging if it was built from the staging.
