### PR TITLE
[Bug # 158324319 ] Fix deployment bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := andelasocietiesbackend
-REPO_NAME ?= andela-societies-backend
+REPO_NAME ?= soc-backend
 ORG_NAME ?= bench-projects
 # File names
 DOCKER_TEST_COMPOSE_FILE := docker/test/docker-compose.yml


### PR DESCRIPTION


## Resolves # 158324319
## Description (what problem you're fixing)

  - Currently the deployment pipeline deploys an image to the wrong container registry folder on GCP.
  
## Fix (what you did to fix it)

  - Point the deployment to the right folder.

## How to test (describe how to test your PR)

  - Changes to deployment should be visible from now on.
  
