### PR TITLE
[feat:(logged-activity) #158252789 ] Add number of participants to logged activity

### DIFF
--- a/src/api/endpoints/activity_types.py
+++ b/src/api/endpoints/activity_types.py
@@ -37,7 +37,9 @@ class ActivityTypesAPI(Resource):
 
         activity_type = ActivityType(name=result["name"],
                                      description=result["description"],
-                                     value=result["value"])
+                                     value=result["value"],
+                                     supports_multiple_participants=result["supports_multiple_participants"]
+                                     )
         activity_type.save()
         return response_builder(dict(
                     status="success",
@@ -96,6 +98,8 @@ class ActivityTypesAPI(Resource):
             target_activity_type.description = payload.get("description")
         if payload.get("value"):
             target_activity_type.value = payload.get("value")
+        if payload.get("supports_multiple_participant"):
+            target_activity_type.supports_multiple_participants = payload.get("supports_multiple_participants")
         return response_builder(dict(
                 message="Edit successful",
                 path=target_activity_type.serialize(),

--- a/src/api/endpoints/logged_activities.py
+++ b/src/api/endpoints/logged_activities.py
@@ -82,6 +82,7 @@ class LoggedActivitiesAPI(Resource):
                 society=society, user=g.current_user,
                 activity=parsed_result.activity,
                 photo=result.get('photo'), value=parsed_result.activity_value,
+                no_of_participants=result.get('no_of_participants'),
                 activity_type=parsed_result.activity_type,
                 activity_date=parsed_result.activity_date
             )

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -201,6 +201,7 @@ class ActivityType(Base):
 
     __tablename__ = 'activity_types'
     value = db.Column(db.Integer)
+    supports_multiple_participants = db.Column(db.Boolean, default=False)
 
     activities = db.relationship('Activity', backref='activity_type')
 
@@ -225,6 +226,7 @@ class LoggedActivity(Base):
     approved_at = db.Column(db.DateTime)
     activity_date = db.Column(db.Date)
     redeemed = db.Column(db.Boolean, nullable=False, default=False)
+    no_of_participants = db.Column(db.Integer)
 
     approver_id = db.Column(db.String)
     reviewer_id = db.Column(db.String)

--- a/src/api/utils/helpers.py
+++ b/src/api/utils/helpers.py
@@ -22,8 +22,8 @@ def parse_log_activity_fields(result):
             return response_builder(dict(message='Invalid activity id'), 422)
 
         activity_type = activity.activity_type
-        if activity_type.name == 'Bootcamp Interviews' and \
-                not (result.get('no_of_interviewees')
+        if activity_type.supports_multiple_participants and \
+                not (result.get('no_of_participants')
                      and result.get('description')):
             return response_builder(dict(
                 message='Please send the number of interviewees and'
@@ -53,8 +53,8 @@ def parse_log_activity_fields(result):
         ), 422)
 
     activity_value = activity_type.value if not \
-        activity_type.name == 'Bootcamp Interviews' else \
-        activity_type.value * result['no_of_interviewees']
+        activity_type.supports_multiple_participants else \
+        activity_type.value * result['no_of_participants']
 
     return ParsedResult(
         activity, activity_type, activity_date, activity_value

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -273,7 +273,8 @@ class BaseTestCase(TestCase):
             name="Bootcamp Interviews",
             description="Interviewing candidate for a fellow"
             " recruiting event",
-            value=20
+            value=20,
+            supports_multiple_participants=True
         )
 
         # test Activity

--- a/src/tests/test_activity_types.py
+++ b/src/tests/test_activity_types.py
@@ -26,7 +26,8 @@ class ActivityTypesTestCase(BaseTestCase):
         new_activity_type = dict(name="Blog Editor",
                                  description="Taking responsibilty for editing"
                                  " a blog for the Andela Way.",
-                                 value=1000)
+                                 value=1000,
+                                 supports_multiple_participants=False)
 
         response = self.client.post("/api/v1/activity-types",
                                     data=json.dumps(new_activity_type),
@@ -43,7 +44,8 @@ class ActivityTypesTestCase(BaseTestCase):
         """Test duplication of activity type is unsuccessful."""
         new_activity_type = dict(name="Hackathon",
                                  description="A Hackathon",
-                                 value=1000)
+                                 value=1000,
+                                 supports_multiple_participants=False)
 
         response = self.client.post("/api/v1/activity-types",
                                     data=json.dumps(new_activity_type),
@@ -88,7 +90,8 @@ class ActivityTypesTestCase(BaseTestCase):
         """Test editing of existing activity type is successful."""
         edit_activity_type = dict(name="Look at me",
                                   description="You think this is a game!!!",
-                                  value=1000)
+                                  value=1000,
+                                  supports_multiple_participants=False)
 
         response = self.client.put(
                         f"/api/v1/activity-types/{self.hackathon.uuid}",

--- a/src/tests/test_logged_activities.py
+++ b/src/tests/test_logged_activities.py
@@ -121,7 +121,7 @@ class LogActivityTestCase(BaseTestCase):
         # test that request is now successful
         self.assertEqual(response.status_code, 201)
 
-    def test_log_interview_activity_requires_no_of_interviewees(self):
+    def test_log_activity_type_that_supports_multi_participants_requires_no_of_participants(self):
         """
         Test that logging an interview activity fails
         without the no_of_interviewees field.
@@ -141,7 +141,7 @@ class LogActivityTestCase(BaseTestCase):
         # test that response status_code is 400
         self.assertEqual(response.status_code, 400)
 
-        data['noOfInterviewees'] = 5
+        data['noOfParticipants'] = 5
         payload = json.dumps(data)
         response = self.client.post(
             'api/v1/logged-activities',
@@ -165,7 +165,7 @@ class LogActivityTestCase(BaseTestCase):
         # test that response status_code is 400
         self.assertEqual(response.status_code, 400)
 
-        data['noOfInterviewees'] = 5
+        data['noOfParticipants'] = 5
         payload = json.dumps(data)
         response = self.client.post(
             'api/v1/logged-activities',


### PR DESCRIPTION
## Resolves 
- #158252789

## Description (what problem you're fixing)
- Activity types supporting multiple participants
- Activity types supporting multiple participants to automatically request number of participants when logging an activity

## Fix (what you did to fix it)
- add support multiple participants field to activity type model
- add no of participants to logged activity model
- run database migration and upgrade
- modify affected model's schemas, helper functions and CRUD endpoints to reflect changes

## How to test (describe how to test your PR)
- run `python manage.py tests`
