### PR TITLE
[Chore #158453829] Rabbitmq Dependency for Notifcations

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -13,6 +13,8 @@ RUN sed -i "s/http:\/\/archive./http:\/\/nz.archive./g" /etc/apt/sources.list
 # Install current stable versions of pip and wheel
 RUN pip install pip==10.0.0 wheel==0.31.0
 
+RUN apt-get -y update && apt-get -y upgrade && apt-get install -y rabbitmq-server
+
 VOLUME /build
 
 WORKDIR /application

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,8 @@
 
 set -o errexit
 set -o pipefail
- 
+
+/etc/init.d/rabbitmq-server start 
 coverage run -m pytest -v
 coverage html
 coveralls


### PR DESCRIPTION
## Resolves #158453829

## Description (what problem you're fixing)

  - The notifications need RabbitMQ to be running in the background as the broker to serve the notifications module.

## Fix (what you did to fix it)

  - Install and run RabbitMQ in the Docker Container

## How to test (describe how to test your PR)

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.
