### PR TITLE
[Feature #158909537/ #157693918] Add fetch all logged activities and update delete logged activity

### DIFF
--- a/src/api/utils/auth.py
+++ b/src/api/utils/auth.py
@@ -135,7 +135,7 @@ def store_user_details(payload, token):
     user.roles = [
         Role.query.filter_by(name=role.lower()).first() for role in roles
         if role and role != "Andelan" and Role.query.filter_by(
-                name=role.lower()).first() is not None]
+            name=role.lower()).first() is not None]
     user.save()
     return user
 

--- a/src/api/utils/marshmallow_schemas.py
+++ b/src/api/utils/marshmallow_schemas.py
@@ -118,6 +118,12 @@ class LoggedActivitySchema(BaseSchema):
         return
 
 
+class LoggedActivitiesSchema(LoggedActivitySchema):
+    date = fields.Date(attribute='activity_date', dump_to='activityDate')
+    society = fields.Nested('BaseSchema', only=('uuid', 'name'))
+    user = fields.String(attribute='user.name', dump_to='owner')
+
+
 class ActivitySchema(BaseSchema):
     """Creates a validation schema for activities."""
 
@@ -136,7 +142,7 @@ class ActivitySchema(BaseSchema):
     activity_date = fields.Date(
         required=True, dump_to='activityDate', load_from='activityDate',
         error_messages={
-                'required': {'message': 'An activity date is required.'}
+            'required': {'message': 'An activity date is required.'}
         })
     added_by_id = fields.String(
         dump_only=True, dump_to='addedById', load_from='addedById'
@@ -291,11 +297,14 @@ class RedemptionSchema(BaseSchema):
 activity_types_schema = ActivityTypesSchema(many=True)
 new_activity_type_schema = ActivityTypesSchema()
 activity_schema = ActivitySchema()
+
 single_logged_activity_schema = LoggedActivitySchema()
 log_edit_activity_schema = LogEditActivitySchema()
 user_logged_activities_schema = LoggedActivitySchema(
     many=True, exclude=('society', 'society_id')
 )
+logged_activities_schema = LoggedActivitiesSchema(many=True)
+
 role_schema = RoleSchema()
 cohort_schema = CohortSchema()
 base_schema = BaseSchema()

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -63,7 +63,7 @@ class BaseTestCase(TestCase):
             }
         },
         "exp": exp_date + datetime.timedelta(days=1)
-        }
+    }
 
     test_auth_role_payload = {
         "UserInfo": {
@@ -181,17 +181,17 @@ class BaseTestCase(TestCase):
         self.success_ops = {
             "Authorization": self.generate_token(self.test_successops_payload),
             "Content-Type": "application/json"
-            }
+        }
         self.society_president = {
             "Authorization": self.generate_token(
-                                self.test_society_president_role_payload),
+                self.test_society_president_role_payload),
             "Content-Type": "application/json"
-            }
+        }
         self.cio = {
             "Authorization": self.generate_token(
-                                self.test_cio_role_payload),
+                self.test_cio_role_payload),
             "Content-Type": "application/json"
-            }
+        }
         self.bad_token_header = {
             "Authorization": self.generate_token(
                 {"I don't know": "what to put here"}
@@ -251,7 +251,7 @@ class BaseTestCase(TestCase):
             center=self.nigeria,
             cohort=self.cohort_1_Nig,
             society=self.phoenix
-            )
+        )
         self.test_user_2 = User(
             uuid="-KdQsawesome_usedk2cckjfbi",
             name="Test User2",


### PR DESCRIPTION
## Resolves #158909537/ #157693918

## Description

  - Currently, there isn't an endpoint that serves all logged activities
  - Users should not be able to delete logged activities that are no longer in review

## Fix

  - An endpoint `/api/v1/logged-activities` has been created to respond with all logged activities on record.
NB: It accepts a `paginate` query parameter when there is a need to fetch all logged activities without pagination
  - A check has been implemented when users attempt to delete logged activities that ensures the logged activity can only be deleted while it's `in review`.

## How to test (describe how to test your PR)

- Clone the repository, install Docker, run `make test` within the repository.
- Trigger a build on CircleCI.
- Run `python run_tests.py` at the root of the `src` directory.
