### PR TITLE
WIP: [Feature #157693824] Add ability for success ops to approve or reject logged activities

### DIFF
--- a/src/api/utils/initial_data.py
+++ b/src/api/utils/initial_data.py
@@ -131,15 +131,15 @@ societies = [phoenix, istelle, sparks, invictus]
 
 # roles available
 roles = [
-         Role(uuid="-KXGy1EB1oimjQgFim6F", name="success"),
-         Role(uuid="-KXGy1EB1oimjQgFim6L", name="finance"),
-         Role(uuid="-KXGy1EB1oimjQgFim6C", name="fellow"),
-         Role(uuid="-KkLwgbeJUO0dQKsEk1i", name="success ops"),
-         Role(uuid="-KiihfZoseQeqC6bWTau", name="andelan"),
-         Role(name="society president"),
-         Role(name="society vice president"),
-         Role(name="society secretary")
-         ]
+    Role(uuid="-KXGy1EB1oimjQgFim6F", name="success"),
+    Role(uuid="-KXGy1EB1oimjQgFim6L", name="finance"),
+    Role(uuid="-KXGy1EB1oimjQgFim6C", name="fellow"),
+    Role(uuid="-KkLwgbeJUO0dQKsEk1i", name="success ops"),
+    Role(uuid="-KiihfZoseQeqC6bWTau", name="andelan"),
+    Role(name="society president"),
+    Role(name="society vice president"),
+    Role(name="society secretary")
+]
 
 
 def test_dev_user_seed_data():
@@ -172,6 +172,7 @@ def test_dev_user_seed_data():
         society=phoenix
     )
     president.roles.append(roles[5])
+    president.roles.append(roles[2])
 
     # success ops
     success_ops = User(

--- a/src/api/utils/marshmallow_schemas.py
+++ b/src/api/utils/marshmallow_schemas.py
@@ -136,7 +136,7 @@ class ActivitySchema(BaseSchema):
     activity_date = fields.Date(
         required=True, dump_to='activityDate', load_from='activityDate',
         error_messages={
-                'required': {'message': 'An activity date is required.'}
+            'required': {'message': 'An activity date is required.'}
         })
     added_by_id = fields.String(
         dump_only=True, dump_to='addedById', load_from='addedById'
@@ -282,10 +282,14 @@ class RedemptionRequestSchema(BaseSchema):
 class RedemptionSchema(BaseSchema):
     """Redemption serializer/validator."""
 
-    status = fields.String(dump_only=True, dump_to='status',
-                           validate=[validate.Length(max=36)])
-    value = fields.Integer(dump_only=True, dump_to='value',
-                           validate=[validate.Length(max=36)])
+    status = fields.String(dump_only=True, validate=[validate.Length(max=36)])
+    value = fields.Integer(dump_only=True)
+
+
+class AcceptRejectSchema(Schema):
+    """Redemption serializer/validator."""
+
+    status = fields.String(validate=[validate.OneOf(['approved', 'rejected'])])
 
 
 activity_types_schema = ActivityTypesSchema(many=True)
@@ -302,5 +306,7 @@ base_schema = BaseSchema()
 user_schema = UserSchema()
 basic_info_schema = BaseSchema()
 society_schema = SocietySchema()
+
 redemption_request_schema = RedemptionRequestSchema()
 redemption_schema = RedemptionSchema()
+accept_reject_schema = AcceptRejectSchema()

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -63,7 +63,7 @@ class BaseTestCase(TestCase):
             }
         },
         "exp": exp_date + datetime.timedelta(days=1)
-        }
+    }
 
     test_auth_role_payload = {
         "UserInfo": {
@@ -161,11 +161,12 @@ class BaseTestCase(TestCase):
         self.client = self.app.test_client()
 
         token_payloads_list = [
-             self.incomplete_payload,
-             self.expired_payload,
-             self.test_cio_role_payload,
-             self.test_society_president_role_payload,
-             self.test_auth_role_payload
+            self.incomplete_payload,
+            self.expired_payload,
+            self.test_cio_role_payload,
+            self.test_society_president_role_payload,
+            self.test_auth_role_payload,
+            self.test_successops_payload
         ]
 
         for token_payload in token_payloads_list:
@@ -181,17 +182,17 @@ class BaseTestCase(TestCase):
         self.success_ops = {
             "Authorization": self.generate_token(self.test_successops_payload),
             "Content-Type": "application/json"
-            }
+        }
         self.society_president = {
             "Authorization": self.generate_token(
-                                self.test_society_president_role_payload),
+                self.test_society_president_role_payload),
             "Content-Type": "application/json"
-            }
+        }
         self.cio = {
             "Authorization": self.generate_token(
-                                self.test_cio_role_payload),
+                self.test_cio_role_payload),
             "Content-Type": "application/json"
-            }
+        }
         self.bad_token_header = {
             "Authorization": self.generate_token(
                 {"I don't know": "what to put here"}
@@ -251,7 +252,7 @@ class BaseTestCase(TestCase):
             center=self.nigeria,
             cohort=self.cohort_1_Nig,
             society=self.phoenix
-            )
+        )
         self.test_user_2 = User(
             uuid="-KdQsawesome_usedk2cckjfbi",
             name="Test User2",


### PR DESCRIPTION
## Resolves #157693824

## Description

  - Currently, success ops do not have a feature to allow them to approve or reject logged activities

## Fix

  - An endpoint `PATCH /api/v1/logged-activities/<logged_activtity_id>` has been provided to enable success ops to update the status of a pending logged activity to `approved` or `rejected`.

## How to test (describe how to test your PR)

- Clone the repository, install Docker, run `make test` within the repository.
- Trigger a build on CircleCI.
- Run `python run_tests.py` at the root of the `src` directory.
