### PR TITLE
#159301341 Edit a logged activity without requiring an activityTypeID

### DIFF
--- a/src/api/endpoints/logged_activities.py
+++ b/src/api/endpoints/logged_activities.py
@@ -144,7 +144,9 @@ class LoggedActivityAPI(Resource):
         payload = request.get_json(silent=True)
 
         if payload:
+            log_edit_activity_schema.context = {'edit': True}
             result, errors = log_edit_activity_schema.load(payload)
+            log_edit_activity_schema.context = {}
 
             if errors:
                 return response_builder(dict(validationErrors=errors), 400)
@@ -160,7 +162,11 @@ class LoggedActivityAPI(Resource):
                 return response_builder(dict(
                     message='Not allowed. Activity is already in pre-approval.'
                 ), 401)
+            if not result.get('activity_type_id'):
+                result['activity_type_id'] = logged_activity.activity_type_id
 
+            if not result.get('date'):
+                result['date'] = logged_activity.activity_date
             parsed_result = parse_log_activity_fields(result)
             if not isinstance(parsed_result, ParsedResult):
                 return parsed_result

--- a/src/api/utils/marshmallow_schemas.py
+++ b/src/api/utils/marshmallow_schemas.py
@@ -188,7 +188,7 @@ class LogEditActivitySchema(BaseSchema):
         validate=[validate.Length(max=36)], load_from='activityId'
     )
     activity_type_id = fields.String(
-        validate=[validate.Length(max=36)], load_from='activityTypeId'
+        validate=[validate.Length(max=36)], load_from='activityTypeId', required=False
     )
     date = fields.Date()
     no_of_participants = fields.Integer(load_from='noOfParticipants')
@@ -196,12 +196,13 @@ class LogEditActivitySchema(BaseSchema):
     @validates_schema
     def validate_logged_activity(self, data):
         """Validate the logged activity."""
-        if (data.get('activity_type_id') and data.get('activity_id')) or not \
-                data.get('activity_type_id') and not data.get('activity_id'):
-            raise ValidationError(
-                'Please send either an activityTypeId or an activityId only',
-                'error'
-            )
+        if not self.context.get('edit'):
+            if (data.get('activity_type_id') and data.get('activity_id')) or not \
+                    data.get('activity_type_id') and not data.get('activity_id'):
+                raise ValidationError(
+                    'Please send either an activityTypeId or an activityId only',
+                    'error'
+                )
 
         if data.get('activity_type_id') and not(data.get('date')
                                                 and data.get('description')):


### PR DESCRIPTION
## Description
  - Allow editing of a logged activity without requiring activityId.
  - Update without requiring date to be provided.

## Fix
  - Use the logged_activity_id passed in the edit endpoint to update a logged activity.
  - Only update date if it is provided in the payload.
 

## How to test
- Clone the repository, run the application
- Access the edit logged activity endpoint, and editing should be possible without putting activity id.
