### PR TITLE
[Feature #159521401] Finance Involvement in Redemption Requests

### DIFF
--- a/src/api/utils/helpers.py
+++ b/src/api/utils/helpers.py
@@ -239,13 +239,13 @@ def add_extra_user_info(token, user_id, url=os.environ.get('ANDELA_API_URL')):  
     return cohort, location, api_response
 
 
-def serialize_redmp(redmption):
+def serialize_redmp(redemption):
     """To serialize and package redeptions."""
-    serial_data, _ = redemption_schema.dump(redmption)
-    seriallized_user, _ = basic_info_schema.dump(redmption.user)
+    serial_data, _ = redemption_schema.dump(redemption)
+    seriallized_user, _ = basic_info_schema.dump(redemption.user)
     serilaized_society, _ = basic_info_schema.dump(
-        Society.query.get(redmption.user.society_id))
+        Society.query.get(redemption.user.society_id))
     serial_data["user"] = seriallized_user
     serial_data["society"] = serilaized_society
-    serial_data["center"], _ = basic_info_schema.dump(redmption.center)
+    serial_data["center"], _ = basic_info_schema.dump(redemption.center)
     return serial_data

--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,8 @@ from api.endpoints.activity_types import ActivityTypesAPI
 from api.endpoints.activities import ActivitiesAPI
 from api.endpoints.societies import SocietyResource, AddCohort
 from api.endpoints.redemption_requests import PointRedemptionAPI
-from api.endpoints.redemption_requests import PointRedemptionRequestNumeration
+from api.endpoints.redemption_requests import RedemptionRequestNumeration
+from api.endpoints.redemption_requests import RedemptionRequestFunds
 from api.endpoints.users import UserAPI
 from api.endpoints.logged_activities import (UserLoggedActivitiesAPI,
                                              SecretaryReviewLoggedAcivityApi)
@@ -122,10 +123,17 @@ def create_app(environment="Development"):
     )
 
     api.add_resource(
-        PointRedemptionRequestNumeration,
+        RedemptionRequestNumeration,
         "/api/v1/societies/redeem/verify/<string:redeem_id>",
         "/api/v1/societies/redeem/verify/<string:redeem_id>/",
-        endpoint="point_redemption_numeration"
+        endpoint="redemption_numeration"
+    )
+
+    api.add_resource(
+        RedemptionRequestFunds,
+        "/api/v1/societies/redeem/funds/<string:redeem_id>",
+        "/api/v1/societies/redeem/funds/<string:redeem_id>/",
+        endpoint="redemption_request_funds"
     )
 
     # Add Cohort to society

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -83,6 +83,22 @@ class BaseTestCase(TestCase):
         "exp": exp_date + datetime.timedelta(days=1)
     }
 
+    test_finance_payload = {
+        "UserInfo": {
+            "email": "test.cio@andela.com",
+            "first_name": "Test",
+            "id": "-Ktest_id",
+            "last_name": "Finance",
+            "name": "test test",
+            "picture": "https://www.link.com",
+            "roles": {
+                    "Andelan": "-Ktest_andelan_id",
+                    "finance": "-KXGy1EB1oimjQgFim6L"
+            }
+        },
+        "exp": exp_date + datetime.timedelta(days=1)
+    }
+
     test_auth_role_payload = {
         "UserInfo": {
             "email": "test.test@andela.com",
@@ -199,7 +215,8 @@ class BaseTestCase(TestCase):
              self.expired_payload,
              self.test_cio_role_payload,
              self.test_society_president_role_payload,
-             self.test_auth_role_payload
+             self.test_auth_role_payload,
+             self.test_finance_payload
         ]
 
         for token_payload in token_payloads_list:
@@ -230,6 +247,11 @@ class BaseTestCase(TestCase):
         self.cio = {
             "Authorization": self.generate_token(
                 self.test_cio_role_payload),
+            "Content-Type": "application/json"
+        }
+        self.finance = {
+            "Authorization": self.generate_token(
+                self.test_finance_payload),
             "Content-Type": "application/json"
         }
         self.bad_token_header = {

--- a/src/tests/test_redemption_requests.py
+++ b/src/tests/test_redemption_requests.py
@@ -334,7 +334,7 @@ class PointRedemptionBaseTestCase(BaseTestCase):
 
 
 class PointRedemptionApprovalTestCase(BaseTestCase):
-    """Test class for Society point redemption approval/rejection."""
+    """Test class for point redemption completion/approval/rejection."""
 
     def setUp(self):
         """Set up all needed variables."""
@@ -342,6 +342,7 @@ class PointRedemptionApprovalTestCase(BaseTestCase):
         self.president_role.save()
         self.v_president_role.save()
         self.successops_role.save()
+        self.finance_role.save()
         self.invictus.save()
         self.istelle.save()
         self.sparks.save()
@@ -407,6 +408,27 @@ class PointRedemptionApprovalTestCase(BaseTestCase):
         )
 
         message = "status changed"
+        response_details = json.loads(response.data)
+
+        self.assertIn(message, response_details["message"])
+        self.assertEqual(response.status_code, 200)
+
+    def test_point_redemption_completion_successful(self):
+        """Test completion of RedemptionRequest.
+
+        When a redemption request funds have been sent out the redemption
+        reequest should be marked as completed.
+        """
+        completion_payload = dict(status="completed")
+
+        response = self.client.put(
+                    f"api/v1/societies/redeem/funds/{self.redemp_req.uuid}",
+                    data=json.dumps(completion_payload),
+                    headers=self.finance,
+                    content_type='application/json'
+        )
+
+        message = "completed"
         response_details = json.loads(response.data)
 
         self.assertIn(message, response_details["message"])


### PR DESCRIPTION
## Resolves #<issue number>

## Description (what problem you're fixing)

 - The finance dept. needed the ability to change the status of a redemption request to completed once the funds have already been sent out.
 - They also needed to be notified when a redemption request is approved by the CIO so they can begin processing payment.

## Fix (what you did to fix it)

  - Added notifications that will be emailed to the relevant center for the Redemption Request.
  - Added functionality that only Finance members can change the status of a redemption request to completed.

## How to test (describe how to test your PR)

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.
