### PR TITLE
#159427418 Approve multiple logged activities

### DIFF
--- a/src/api/endpoints/logged_activities.py
+++ b/src/api/endpoints/logged_activities.py
@@ -243,3 +243,69 @@ class SecretaryReviewLoggedAcivityApi(Resource):
             dict(data=single_logged_activity_schema.dump(logged_activity).data,
                  message="successfully changed status"),
             200)
+
+
+class LoggedActivityApprovalAPI(Resource):
+    """Allows success-ops to approve at least one Logged Activities."""
+
+    decorators = [token_required]
+
+    @classmethod
+    @roles_required(["success ops"])
+    def put(cls, logged_activity_id=None):
+        """Put method for approving logged Activity resource."""
+
+        # TODO: Adding of redemption points needs to be factored into this
+        payload = request.get_json(silent=True)
+
+        if payload:
+            logged_activities_ids = payload.get('loggedActivitiesIds', None)
+
+            if logged_activities_ids is None:
+                return response_builder(dict(
+                    message='loggedActivitiesIds is required'), 400)
+
+            if len(logged_activities_ids) > 20:
+                return response_builder(dict(
+                    message='Sorry, you can not approve more than 20 logged_activities at a go'), 406)
+
+            if not isinstance(logged_activities_ids, list) or not logged_activities_ids:
+                return response_builder(dict(
+                    message='A List/Array with at least one logged activity id is needed!'), 400)
+
+            unique_activities_ids = set([])
+            for logged_activities_id in logged_activities_ids:
+                logged_activities = LoggedActivity.query.get(logged_activities_id)
+                if logged_activities is None or logged_activities.redeemed\
+                or logged_activities.status in  ['rejected', 'in review', 'approved']:
+                    continue
+                unique_activities_ids.add(logged_activities)
+
+            if len(unique_activities_ids) == 0:
+                return response_builder(dict(
+                    status='failed',
+                    message='Invalid logged activities or no pending logged activities in request'),
+                    400)
+            else:
+                for unique_activities_id in list(unique_activities_ids):
+                    unique_activities_id.status = 'approved'
+
+                user_logged_activities = logged_activities_schema.dump(
+                    unique_activities_ids).data
+
+                # NOTE: this code works as expected, shipping it out for the MVP
+                # further optimization will be done from line 254 - 257
+                # using marshmallow
+                for user_logged_activity in user_logged_activities:
+                    user_logged_activity['society'] = {'id': user_logged_activity['societyId'],
+                    'name': user_logged_activity['society']}
+                    del user_logged_activity['society']['id']
+                    del user_logged_activity['societyId']
+                return response_builder(dict(
+                    data=user_logged_activities,
+                    message='Activity edited successfully'),
+                    200)
+        else:
+            return response_builder(dict(
+                                message='Data for creation must be provided.'),
+                                400)

--- a/src/api/utils/marshmallow_schemas.py
+++ b/src/api/utils/marshmallow_schemas.py
@@ -81,8 +81,8 @@ class LoggedActivitySchema(BaseSchema):
 
     status = fields.String()
     points = fields.Integer(attribute='value')
-    date = fields.Date(attribute='activity_date')
-    user = fields.String(attribute='user.name')
+    date = fields.Date(attribute='activity_date', dump_to='activityDate', load_from='activityDate')
+    owner = fields.String(attribute='user.name')
     activity_id = fields.String(dump_to='activityId', load_from='activityId')
     activity = fields.String(attribute='activity.name')
     category = fields.String(attribute='activity_type.name')
@@ -305,7 +305,6 @@ user_logged_activities_schema = LoggedActivitySchema(
     many=True, exclude=('society', 'society_id')
 )
 logged_activities_schema = LoggedActivitiesSchema(many=True)
-
 role_schema = RoleSchema()
 cohort_schema = CohortSchema()
 base_schema = BaseSchema()

--- a/src/app.py
+++ b/src/app.py
@@ -14,6 +14,7 @@ from api.endpoints.logged_activities import (UserLoggedActivitiesAPI,
                                              SecretaryReviewLoggedAcivityApi)
 from api.endpoints.logged_activities import LoggedActivitiesAPI
 from api.endpoints.logged_activities import LoggedActivityAPI
+from api.endpoints.logged_activities import LoggedActivityApprovalAPI
 from api.endpoints.roles import RoleAPI, SocietyRoleAPI
 from api.models import db
 
@@ -149,6 +150,12 @@ def create_app(environment="Development"):
         SocietyRoleAPI, "/api/v1/roles/society-execs",
         "/api/v1/roles/society-execs/",
         endpoint="society_execs_roles"
+    )
+
+    api.add_resource(LoggedActivityApprovalAPI,
+        "/api/v1/approve/logged-activities",
+        "/api/v1/approve/logged-activities/",
+        endpoint="approve_logged_activities"
     )
 
     # enable health check ping to API

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -394,6 +394,16 @@ class BaseTestCase(TestCase):
             activity_type=self.hackathon
         )
 
+        self.log_alibaba_challenge2 = LoggedActivity(
+            name="my second logged activity",
+            description="Participated in this event",
+            value=2500,
+            user=self.test_user,
+            activity=self.alibaba_ai_challenge,
+            society=self.sparks,
+            activity_type=self.hackathon
+        )
+
         self.redemp_req = RedemptionRequest(
             name="T-shirt Funds Request",
             value=2500,

--- a/src/tests/test_logged_activities.py
+++ b/src/tests/test_logged_activities.py
@@ -516,6 +516,173 @@ class EditLoggedActivityTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 400)
 
 
+class LoggedActivityApprovalTestCase(BaseTestCase):
+    """Test to check approval of Logged activities by success ops"""
+
+    def test_approving_logged_activities_successful(self):
+
+        """
+        Test a scenario where approval for logged activities passes
+        if the user is a successops.
+        """
+
+        self.successops_role.save()
+        self.log_alibaba_challenge.status = 'pending'
+        self.log_alibaba_challenge2.status = 'pending'
+        self.log_alibaba_challenge.save()
+        self.log_alibaba_challenge2.save()
+
+        self.payload = dict(
+            loggedActivitiesIds=[self.log_alibaba_challenge.uuid, self.log_alibaba_challenge2.uuid]
+        )
+
+        response = self.client.put(
+           f'/api/v1/approve/logged-activities',
+           data=json.dumps(self.payload),
+           headers=self.success_ops
+        )
+
+        message = 'Activity edited successfully'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_details['message'], message)
+        self.assertEqual(response_details['data'][0]['status'], 'approved')
+
+
+    def test_approving_logged_activities_unsuccessful(self):
+
+        """
+        Test a scenario where approval for logged activities fails
+        if the user is not a successops.
+        """
+
+        self.successops_role.save()
+        self.log_alibaba_challenge.status = 'pending'
+        self.log_alibaba_challenge2.status = 'rejected'
+        self.log_alibaba_challenge.save()
+        self.log_alibaba_challenge2.save()
+
+        self.payload = dict(
+            loggedActivitiesIds=[self.log_alibaba_challenge.uuid, self.log_alibaba_challenge2.uuid]
+        )
+
+        response = self.client.put(
+           f'/api/v1/approve/logged-activities',
+           data=json.dumps(self.payload),
+           headers=self.header
+        )
+
+        message = 'You\'re unauthorized to perform this operation'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response_details['message'], message)
+
+
+    def test_approving_logged_activities_empty_request_fails(self):
+
+        """
+        Test a scenario where approval for logged activities passes
+        if the user is a successops.
+        """
+
+        self.successops_role.save()
+
+        self.payload = dict(
+            loggedActivitiesIds=[self.log_alibaba_challenge.uuid, self.log_alibaba_challenge2.uuid]
+        )
+
+        response = self.client.put(
+           '/api/v1/approve/logged-activities',
+           headers=self.success_ops
+        )
+
+        message = 'Data for creation must be provided.'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_details['message'], message)
+
+
+    def test_approving_logged_activities_id_is_string_fails(self):
+
+        """
+        Test a scenario where approval for logged activities fails when
+        logged_activities_ids request payload is of type string.
+        """
+
+        self.successops_role.save()
+        self.payload = dict(
+            loggedActivitiesIds='400404004040'
+        )
+
+        response = self.client.put(
+           f'/api/v1/approve/logged-activities',
+           data=json.dumps(self.payload),
+           headers=self.success_ops
+        )
+
+        message = 'A List/Array with at least one logged activity id is needed!'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_details['message'], message)
+
+
+    def test_approving_over_twenty_logged_activities_fails(self):
+
+        """
+        Test a scenario where approval for logged activities fails
+        if logged activities request is more than 20.
+        """
+
+        self.successops_role.save()
+        self.payload = dict(
+            status='approved',
+            loggedActivitiesIds=['i' for count in range(0,21)]
+        )
+
+        response = self.client.put(
+           f'/api/v1/approve/logged-activities',
+           data=json.dumps(self.payload),
+           headers=self.success_ops
+        )
+
+        message = 'Sorry, you can not approve more than 20 logged_activities at a go'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 406)
+        self.assertEqual(response_details['message'], message)
+
+
+    def test_approving_when_all_logged_activities_invalid_fails(self):
+
+        """
+        Test a scenario where approval for logged activities fails
+        when logged_activities_id supplied are invalid or are not
+        in pending state
+        """
+
+        self.successops_role.save()
+
+        self.payload = dict(
+            loggedActivitiesIds=['13567788', '235555666']
+        )
+
+        response = self.client.put(
+           f'/api/v1/approve/logged-activities',
+           data=json.dumps(self.payload),
+           headers=self.success_ops
+        )
+
+        message = 'Invalid logged activities or no pending logged activities in request'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response_details['message'], message)
+
+
 class DeleteLoggedActivityTestCase(BaseTestCase):
     """Delete logged activity test cases."""
 


### PR DESCRIPTION
#### Description (what problem you're fixing)
- Allow a success-ops user approve multiple logged activities.
- Logged activities are approved in sets of twenty.

#### Fix (what you did to fix it)
 - Implement endpoint to allow success-ops to approve multiple logged activities.
 - Updated logged activity schema to display `society` and `societyId`.
 - Updated logged activity schema to display `date` as `activityDate`.

#### How to test (describe how to test your PR)
- Clone the repository, install docker and rabbitmq-app, run `make test` within the repository.
- Trigger a build on CircleCI.
