### PR TITLE
[Chore] Fix the finance email generator

### DIFF
--- a/src/api/endpoints/redemption_requests.py
+++ b/src/api/endpoints/redemption_requests.py
@@ -239,11 +239,11 @@ class RedemptionRequestNumeration(Resource):
 
             # Get the relevant Finance Center to respond on RedemptionRequest
             if str(redemp_request.center.name.lower()) == 'kampala':
-                finance_email = str(redemp_request.center.name.lower())+".fin"
-                "ance@andela.com"
+                finance_email = redemp_request.center.name.lower() + \
+                    ".finance@andela.com"
             else:
-                finance_email = str(redemp_request.center.name.lower())+"-fin"
-                "ance@andela.com"
+                finance_email = redemp_request.center.name.lower() + \
+                    "-finance@andela.com"
 
             send_email.delay(
                 sender=current_app.config["SENDER_CREDS"],

--- a/src/api/utils/initial_data.py
+++ b/src/api/utils/initial_data.py
@@ -16,9 +16,9 @@ from api.models import (ActivityType, Activity, Center, LoggedActivity,
 def centre_societies_roles_data_dev():
     """Generate center societies and role data"""
     # test centers
-    kenya = Center(name='Kenya')
-    uganda = Center(name='Uganda')
-    nigeria = Center(name='Nigeria')
+    nairobi = Center(name='Nairobi')
+    kampala = Center(name='Kampala')
+    lagos = Center(name='Lagos')
 
     # societies
     phoenix = Society(name="phoenix")
@@ -38,7 +38,7 @@ def centre_societies_roles_data_dev():
             Role(name="society secretary")
          )
 
-    return (roles, kenya, uganda, nigeria, phoenix, istelle, sparks, invictus)
+    return (roles, nairobi, kampala, lagos, phoenix, istelle, sparks, invictus)
 
 
 # setup dev user info to access Andela API
@@ -147,12 +147,12 @@ def activity_types_data():
 
 
 def test_dev_user_seed_data(args):
-    (kenya,
+    (nairobi,
      phoenix,
      roles) = args
 
     # cohorts
-    cohort_14_ke = Cohort(name='Cohort 14 Test', center=kenya)
+    cohort_14_ke = Cohort(name='Cohort 14 Test', center=nairobi)
     # users
     # member
     member = User(
@@ -161,7 +161,7 @@ def test_dev_user_seed_data(args):
         photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
               "AI/AAAAAAAAABc/ImeP_cAI/photo.jpg?sz=50",
         email="test.user.societies@andela.com",
-        center=kenya,
+        center=nairobi,
         cohort=cohort_14_ke,
         society=phoenix
     )
@@ -174,7 +174,7 @@ def test_dev_user_seed_data(args):
         photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
               "AI/AAAAAAnAABc/ImeP_cAI/photo.jpg?sz=50",
         email="test.president.societies@andela.com",
-        center=kenya,
+        center=nairobi,
         cohort=cohort_14_ke,
         society=phoenix
     )
@@ -187,7 +187,7 @@ def test_dev_user_seed_data(args):
         photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
               "AI/AAAAAAnAABc/ImeP_cAI/photo.jpg?sz=50",
         email="test.successops.societies@andela.com",
-        center=kenya
+        center=nairobi
     )
     success_ops.roles.append(roles[3])
 
@@ -254,9 +254,9 @@ def generete_initial_data_run_time_env():
     """
 
     # generete dev data cohort, societies, roles
-    (roles, kenya, uganda, nigeria, phoenix,
+    (roles, nairobi, kampala, lagos, phoenix,
      istelle, sparks, invictus) = centre_societies_roles_data_dev()
-    centers = (kenya, uganda, nigeria)
+    centers = (nairobi, kampala, lagos)
     societies = (phoenix, istelle, sparks, invictus)
 
     api_cohorts = api_centers = ()
@@ -275,7 +275,7 @@ def generete_initial_data_run_time_env():
 
     # generate user data
     args = (
-        kenya,
+        nairobi,
         phoenix,
         roles
     )

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -262,9 +262,9 @@ class BaseTestCase(TestCase):
         }
 
         # test centers
-        self.kenya = Center(name='Kenya')
-        self.uganda = Center(name='Uganda')
-        self.nigeria = Center(name='Nigeria')
+        self.nairobi = Center(name='Nairobi')
+        self.kampala = Center(name='Kampala')
+        self.lagos = Center(name='Lagos')
 
         # test societies
         self.phoenix = Society(name="Phoenix",
@@ -301,9 +301,9 @@ class BaseTestCase(TestCase):
         self.cio_role = Role(uuid="-KXGionceu24i2y", name="cio")
 
         # test cohorts
-        self.cohort_12_Ke = Cohort(name="cohort-12", center=self.kenya)
-        self.cohort_12_Ug = Cohort(name="cohort-12", center=self.uganda)
-        self.cohort_1_Nig = Cohort(name="cohort-1", center=self.nigeria)
+        self.cohort_12_Ke = Cohort(name="cohort-12", center=self.nairobi)
+        self.cohort_12_Ug = Cohort(name="cohort-12", center=self.kampala)
+        self.cohort_1_Nig = Cohort(name="cohort-1", center=self.lagos)
 
         # test users
         self.test_user = User(
@@ -311,7 +311,7 @@ class BaseTestCase(TestCase):
             name="Test User",
             photo="https://www.link.com",
             email="test.user.societies@andela.com",
-            center=self.nigeria,
+            center=self.lagos,
             cohort=self.cohort_1_Nig,
             society=self.phoenix
         )
@@ -320,7 +320,7 @@ class BaseTestCase(TestCase):
             name="Test User2",
             photo="https://www.link.com",
             email="test.user2.societies@andela.com",
-            center=self.uganda,
+            center=self.kampala,
             cohort=self.cohort_12_Ug,
             society=self.sparks
         )
@@ -329,7 +329,7 @@ class BaseTestCase(TestCase):
             name="Test User3",
             photo="https://www.link.com",
             email="test.user3.societies@andela.com",
-            center=self.kenya,
+            center=self.nairobi,
             cohort=self.cohort_12_Ke,
             society=self.invictus
         )
@@ -340,7 +340,7 @@ class BaseTestCase(TestCase):
             photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
                   "AI/AAAAAAnAABc/ImeP_cAI/photo.jpg?sz=50",
             email="test.president.societies@andela.com",
-            center=self.kenya,
+            center=self.nairobi,
             cohort=self.cohort_12_Ke,
             society=self.phoenix
         )
@@ -352,7 +352,7 @@ class BaseTestCase(TestCase):
             photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
                   "AI/AAAAAAnAABc/ImeP_cAI/photo.jpg?sz=50",
             email="test.vice_president.societies@andela.com",
-            center=self.kenya,
+            center=self.nairobi,
             cohort=self.cohort_12_Ke,
             society=self.sparks
         )
@@ -364,7 +364,7 @@ class BaseTestCase(TestCase):
             photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
                   "AI/AAAAAAnAABc/ImeP_cAI/photo.jpg?sz=50",
             email="test.secretary.societies@andela.com",
-            center=self.kenya,
+            center=self.nairobi,
             cohort=self.cohort_12_Ke,
             society=self.invictus
         )
@@ -399,7 +399,7 @@ class BaseTestCase(TestCase):
             added_by=self.president
         )
         self.bootcamp_xiv = Activity(
-            name='Bootcamp XIV Interviews - Kenya',
+            name='Bootcamp XIV Interviews - Nairobi',
             activity_type=self.interview,
             activity_date=datetime.date.today() + datetime.timedelta(days=14),
             added_by=self.president

--- a/src/tests/test_add_cohort.py
+++ b/src/tests/test_add_cohort.py
@@ -12,7 +12,7 @@ class AddCohortTestCase(BaseTestCase):
         self.success_role.save()
 
     def test_add_society(self):
-        self.kenya.save()
+        self.nairobi.save()
         self.istelle.save()
         self.cohort_12_Ke.save()
 
@@ -102,7 +102,7 @@ class AddCohortTestCase(BaseTestCase):
             message="Error Invalid societyId."))
 
     def test_add_society_conflicting_data(self):
-        self.kenya.save()
+        self.nairobi.save()
         self.istelle.save()
         self.istelle.cohorts.append(self.cohort_12_Ke)
         self.cohort_12_Ke.save()

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -16,7 +16,7 @@ class UserTestCase(BaseTestCase):
             photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
                   "AI/AAAAAAAAABc/ImM13eP_cAI/photo.jpg?sz=50",
             email="test.user@andela.com",
-            center=self.kenya,
+            center=self.nairobi,
             cohort=self.cohort_12_Ke)
 
         self.assertTrue(test_user.save())
@@ -36,7 +36,7 @@ class UserTestCase(BaseTestCase):
             photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
                   "AI/AAAAAAAAABc/ImM13eP_cAI/photo.jpg?sz=50",
             email="test.user@andela.com",
-            center=self.kenya,
+            center=self.nairobi,
             cohort=self.cohort_12_Ke)
 
         test_user.save()
@@ -101,7 +101,7 @@ class SocietyTestCase(BaseTestCase):
             photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
                   "AI/AAAAAAAAABc/ImM13eP_cAI/photo.jpg?sz=50",
             email="test.user@andela.com",
-            center=self.kenya,
+            center=self.nairobi,
             cohort=self.cohort_12_Ke)
 
         self.phoenix.members.extend([test_user, self.test_user])
@@ -219,7 +219,7 @@ class CohortTestCase(BaseTestCase):
 
     def test_create_cohort(self):
         """Test creation of a cohort."""
-        cohort_1_Nig = Cohort(name="cohort-1", center=self.nigeria)
+        cohort_1_Nig = Cohort(name="cohort-1", center=self.lagos)
         self.assertTrue(cohort_1_Nig.save())
 
 
@@ -228,9 +228,9 @@ class CenterTestCase(BaseTestCase):
 
     def test_create_center(self):
         """Test create a center."""  # bwahahahahah
-        self.uganda = Center(name='Uganda')
+        self.kampala = Center(name='Kampala')
 
-        self.assertTrue(self.uganda.save())
+        self.assertTrue(self.kampala.save())
 
 
 class RoleTestCase(BaseTestCase):

--- a/src/tests/test_redemption_requests.py
+++ b/src/tests/test_redemption_requests.py
@@ -22,13 +22,13 @@ class PointRedemptionBaseTestCase(BaseTestCase):
 
     def test_create_redemption_request(self):
         """Test creation of Redemption Request through endpoint."""
-        self.nigeria.save()
+        self.lagos.save()
 
         new_request = dict(
             reason="T-shirt Funds Request",
             value=2500,
             user_id=self.test_user.uuid,
-            center="Nigeria"
+            center="Lagos"
             )
 
         response = self.client.post("api/v1/societies/redeem",

--- a/src/tests/test_user_information.py
+++ b/src/tests/test_user_information.py
@@ -23,7 +23,7 @@ class UserInformationTestCase(BaseTestCase):
     def setUp(self):
         """Set up patch information for every test."""
         super().setUp()
-        self.kenya.save()
+        self.nairobi.save()
         self.cohort_12_Ke.save()
         self.society = Society(name="iStelle")
         self.society.cohorts.append(self.cohort_12_Ke)
@@ -32,7 +32,7 @@ class UserInformationTestCase(BaseTestCase):
         cohort = self.cohort_12_Ke
         self.patcher = mock.patch('api.utils.auth.add_extra_user_info',
                                   return_value=info_mock(200,
-                                                         location=self.kenya,
+                                                         location=self.nairobi,
                                                          cohort=cohort,
                                                          society=self.society))
         self.patcher.start()
@@ -51,7 +51,7 @@ class UserInformationTestCase(BaseTestCase):
 
         response_data = json.loads(response.data)
 
-        expected_location_data, _ = basic_info_schema.dump(self.nigeria)
+        expected_location_data, _ = basic_info_schema.dump(self.lagos)
         self.assertDictEqual(response_data.get('data').get('location'),
                              expected_location_data)
         expected_society_data, _ = basic_info_schema.dump(self.phoenix)


### PR DESCRIPTION
## Resolves #N/A

## Description (what problem you're fixing)

  - The finance email generator I wrote to customise the email based off of the location of the redemption request was not generating the full email.

## Fix (what you did to fix it)

  - Put the string on the same line so that the whole email address is correctly generated.
  - Removed the "str()" as it was unnecessary

## How to test (describe how to test your PR)

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.
