### PR TITLE
Add weekly task to email success ops about pending logged activities

### DIFF
--- a/src/.coveragerc
+++ b/src/.coveragerc
@@ -25,3 +25,6 @@ omit =
     */marshmallow_schemas.py
     run_tests.py
     */initial_data.py
+
+# for some reason coverage keeps raising a missing blub file error in the src directory when generating a html report. This is a temporary solution before the root cause can be determined.
+ignore_errors = True

--- a/src/api/endpoints/activity_types.py
+++ b/src/api/endpoints/activity_types.py
@@ -35,12 +35,12 @@ class ActivityTypesAPI(Resource):
             validation_status_code = status_code or 400
             return response_builder(errors, validation_status_code)
 
-        support_mutiple = result["supports_multiple_participants"]
+        support_multiple = result.get("supports_multiple_participants")
         activity_type = ActivityType(
                 name=result["name"],
                 description=result["description"],
                 value=result["value"],
-                supports_multiple_participants=support_mutiple
+                supports_multiple_participants=support_multiple
         )
         activity_type.save()
         return response_builder(dict(

--- a/src/api/endpoints/logged_activities.py
+++ b/src/api/endpoints/logged_activities.py
@@ -103,7 +103,7 @@ class LoggedActivitiesAPI(Resource):
 
     @classmethod
     def get(cls):
-        """Get all logged activities"""
+        """Get all logged activities."""
         paginate = request.args.get("paginate", "true")
         message = "all Logged activities fetched successfully"
 
@@ -140,7 +140,7 @@ class LoggedActivityAPI(Resource):
 
     @classmethod
     def put(cls, logged_activity_id=None):
-        """Log a new activity."""
+        """Edit an activity."""
         payload = request.get_json(silent=True)
 
         if payload:
@@ -254,7 +254,6 @@ class LoggedActivityApprovalAPI(Resource):
     @roles_required(["success ops"])
     def put(cls, logged_activity_id=None):
         """Put method for approving logged Activity resource."""
-
         # TODO: Adding of redemption points needs to be factored into this
         payload = request.get_json(silent=True)
 
@@ -281,7 +280,7 @@ class LoggedActivityApprovalAPI(Resource):
                     continue
                 unique_activities_ids.add(logged_activities)
 
-            if len(unique_activities_ids) == 0:
+            if not unique_activities_ids:
                 return response_builder(dict(
                     status='failed',
                     message='Invalid logged activities or no pending logged activities in request'),
@@ -289,6 +288,7 @@ class LoggedActivityApprovalAPI(Resource):
             else:
                 for unique_activities_id in list(unique_activities_ids):
                     unique_activities_id.status = 'approved'
+                    unique_activities_id.society.total_points = unique_activities_id
 
                 user_logged_activities = logged_activities_schema.dump(
                     unique_activities_ids).data
@@ -320,7 +320,6 @@ class LoggedActivityRejectionAPI(Resource):
     @roles_required(["success ops"])
     def put(cls, logged_activity_id):
         """Put method for rejecting logged activity resource."""
-
         logged_activity = LoggedActivity.query.filter_by(
             uuid=logged_activity_id).first()
 
@@ -346,4 +345,3 @@ class LoggedActivityRejectionAPI(Resource):
                     message='This logged activity is either in-review, approved or already rejected'
                     ),
                     406)
-

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -149,7 +149,6 @@ class User(Base):
                                  secondary='user_activity',
                                  lazy='dynamic',
                                  backref='participants')
-    roles = db.relationship('Role', secondary='user_role', backref='user')
     redemption_requests = db.relationship(
         'RedemptionRequest', backref='user', lazy='dynamic',
         order_by='desc(RedemptionRequest.created_at)'
@@ -160,7 +159,8 @@ class Role(Base):
     """Models Roles to which all Andelans have."""
 
     __tablename__ = 'roles'
-    users = db.relationship('User', secondary='user_role', backref='role')
+    users = db.relationship('User', secondary='user_role', lazy='dynamic',
+                            backref=db.backref('roles', lazy='dynamic'))
 
 
 class Society(Base):

--- a/src/api/utils/helpers.py
+++ b/src/api/utils/helpers.py
@@ -5,10 +5,13 @@ from collections import namedtuple
 
 
 import requests
-from flask import Response, current_app, jsonify, request, url_for
+from flask import (
+    Response, current_app, jsonify, request, url_for
+)
 from api.models import (Activity, ActivityType, Cohort, Center, Role, Society,
-                        RedemptionRequest)
+                        RedemptionRequest, LoggedActivity, db)
 from api.utils.marshmallow_schemas import basic_info_schema, redemption_schema
+
 
 ParsedResult = namedtuple(
     'ParsedResult',

--- a/src/api/utils/marshmallow_schemas.py
+++ b/src/api/utils/marshmallow_schemas.py
@@ -120,7 +120,7 @@ class LoggedActivitySchema(BaseSchema):
 
 class LoggedActivitiesSchema(LoggedActivitySchema):
     date = fields.Date(attribute='activity_date', dump_to='activityDate')
-    society = fields.Nested('BaseSchema', only=('uuid', 'name'))
+    society = fields.Nested(BaseSchema, only=('uuid', 'name'))
     user = fields.String(attribute='user.name', dump_to='owner')
 
 
@@ -271,7 +271,7 @@ class RedemptionRequestSchema(BaseSchema):
         load_from='reason',
         required=True,
         error_messages={
-            'required': {'message': 'A name is required.'}
+            'required': {'message': 'A reason is required.'}
         })
     value = fields.Integer(
         load_from='points',

--- a/src/api/utils/notifications/README_notifications.md
+++ b/src/api/utils/notifications/README_notifications.md
@@ -1,47 +1,68 @@
 # Andela Societies Notifications
+
 ## About
+
 This module implements notifications for this Andela Societies notifications
+
 ## Goal
+
 The goal of this project is to implement notifications asynchronously in the Andela Societies platform
+
 ## Features
+
 With this module;
+
 - You can send email notifications using mail gun
 - TODO: You can send slack notifications
 - TODO: You can send telegram notifications
+
 ## Requirements
+
 - Use Python 3.x.x+
 - Use Flask
+
 ## Tests
-"Code without tests is broken as designed", said  [Jacob Kaplan-Moss](https://jacobian.org/writing/django-apps-with-buildout/#s-create-a-test-wrapper). Therefore i shall not give you code that
+
+"Code without tests is broken as designed", said [Jacob Kaplan-Moss](https://jacobian.org/writing/django-apps-with-buildout/#s-create-a-test-wrapper). Therefore i shall not give you code that
 can not be tested or has no tests. So, to run tests, enter the following command
+
 ```sh
     $ python -m pytest src/tests/test_send_email.py
 ```
+
 ## Usage
+
 To use this module;
+
 - You need to install [RabbitMQ Server](https://www.rabbitmq.com/install-standalone-mac.html) (broker)
 - You need to install [Celery](http://docs.celeryproject.org/en/latest/getting-started/first-steps-with-celery.html) (job server)
 
 After successfully installing RabbitMQ, you will need to set a number of environment variables to get module working.
+
 ```bash
     $ export CELERY_BROKER_URL="amqp://username:password@localhost:port_number//"
     $ export CELERY_BACKEND="rpc://"
-
 ```
 
 Then issue the following commands
+
 ```sh
     $ brew services start rabbitmq
-    $ celery -A api.utils.notifications.celery worker
+    $ celery -A api.utils.notifications.email_notices worker -l info --beat
 ```
+
 You need to set the following environment variables:
+
 ```bash
 export MAIL_GUN_URL="Insert Mailgun URL here."
 export MAIL_GUN_API_KEY="Insert Mailgun API Key here."
 export SENDER_CREDS="Insert MailGun Credentials here."
 export MAIL_GUN_TEST="Whichever string you want for the test variable."
+export NOTIFICATIONS_SENDER="Whichever string you want for the test variable."
 ```
+
 Then in your module/controller do the following:
+
 ```python
 # import the notifications
 from api.utils.notifications.email_notices import send_email

--- a/src/api/utils/notifications/email_notices.py
+++ b/src/api/utils/notifications/email_notices.py
@@ -1,34 +1,35 @@
 """Notifications module."""
-import re
 import os
 import requests
-from flask import current_app
+
 from celery import Celery
+from celery.schedules import crontab
+
+from api.utils.notifications.task_helpers import (
+    generate_success_ops_pending_activities_emails,
+    create_celery_flask, validate_email
+)
 
 
+flask_app = create_celery_flask()
 celery = Celery(
     "notifications",
     broker=os.environ.get("CELERY_BROKER_URL", None),
     backend=os.environ.get("CELERY_BACKEND", None)
 )
 
-
-def validate_email(recipients=None):
-    """
-    Eliminating emails sent to invalid emails.
-
-    This method validates that the recipients list has valid
-    email addresses before send() is invoked
-    :return bool:
-    """
-    regex = "^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$"
-    for email in recipients:
-        if not re.match(regex, email):
-            raise ValueError("invalid email address: {}".format(email))
-    return True
+celery.conf.beat_schedule = {
+    'mail-success-ops': {
+        'task': 'api.utils.notifications.email_notices.mail_success_ops',
+        'schedule': crontab(
+            hour=7, minute=30,
+            day_of_week=flask_app.config['SUCCESS_OPS_NEWSLETTER_DAY']
+        )
+    }
+}
 
 
-@celery.task()
+@celery.task
 def send_email(**kwargs):
     """
     Send the Emails.
@@ -46,29 +47,43 @@ def send_email(**kwargs):
     :kwarg recipients:
     :return bool:
     """
-    mail_gun_url = current_app.config["MAIL_GUN_URL"]
-    mail_gun_api_key = current_app.config["MAIL_GUN_API_KEY"]
-    mail_gun_test = current_app.config.get("MAIL_GUN_TEST")
-
-    if kwargs["sender"] == "":
+    if not kwargs["sender"] or not kwargs["sender"].strip():
         raise ValueError("sender address missing")
 
-    if mail_gun_test:
-        if validate_email(kwargs["recipients"]):
+    validate_email(kwargs["recipients"])
+
+    if os.getenv("MAIL_GUN_TEST"):
             return True
 
-    if validate_email(kwargs["recipients"]):
-        response = requests.post(
-            mail_gun_url,
-            auth=("api", mail_gun_api_key),
-            data={
-                "from": kwargs["sender"],
-                "to": kwargs["recipients"],
-                "subject": kwargs["subject"],
-                "text": kwargs["message"]
-            }
-        )
-        if response.status_code == 200:
-            return True
-        else:
-            return False
+    mail_gun_url = flask_app.config["MAIL_GUN_URL"]
+    mail_gun_api_key = flask_app.config["MAIL_GUN_API_KEY"]
+
+    data = {
+        "from": kwargs["sender"],
+        "to": kwargs["recipients"],
+        "subject": kwargs["subject"],
+        "text": kwargs["message"],
+    }
+    if kwargs.get("html"):
+        data.update(dict(html=kwargs.get("html")))
+    response = requests.post(
+        mail_gun_url, auth=("api", mail_gun_api_key), data=data
+    )
+    if response.status_code == 200:
+        return True
+    else:
+        return False
+
+
+@celery.task
+def mail_success_ops(app=flask_app):
+    """
+    Mail success ops every monday morning when there are pending
+    activities
+    """
+    emails_kwargs_tuple = generate_success_ops_pending_activities_emails(app)
+    if isinstance(emails_kwargs_tuple, tuple):
+        for email_kwargs in emails_kwargs_tuple[1]:
+            send_email.delay(**email_kwargs)
+
+    return emails_kwargs_tuple

--- a/src/api/utils/notifications/task_helpers.py
+++ b/src/api/utils/notifications/task_helpers.py
@@ -1,0 +1,82 @@
+import os
+import re
+
+from flask import Flask, render_template_string
+
+from config import configuration
+from api.models import Role, LoggedActivity, db
+
+
+SUCCESS_OPS_MESSAGE = '''
+Hi {{name}},\n
+There are {{count}} pending logged activities. \n
+Have a great week ahead.\n
+Regards,
+The Andela Societies Team.
+'''
+
+
+def create_celery_flask(environment=os.getenv('APP_SETTINGS', 'Production')):
+    """Factory Method that creates an instance of the app with the given env.
+
+    Args:
+        environment (str): Specify the configuration to initialize app with.
+
+    Return:
+        app (Flask): it returns an instance of Flask.
+    """
+    app = Flask(__name__)
+    app.config.from_object(configuration[environment])
+    db.init_app(app)
+
+    return app
+
+
+def validate_email(recipients=None):
+    """
+    Eliminating emails sent to invalid emails.
+
+    This method validates that the recipients list has valid
+    email addresses before send() is invoked
+    :return bool:
+    """
+    regex = "^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$"
+    for email in recipients:
+        if not re.match(regex, email):
+            raise ValueError("invalid email address: {}".format(email))
+    return True
+
+
+def generate_success_ops_pending_activities_emails(app):
+    '''
+    Get pending logged activities and genrate email for each success ops
+    member
+    '''
+    with app.app_context():
+        success_ops_role = Role.query.filter_by(
+            name='success ops'
+        ).one_or_none()
+
+        success_ops_members = success_ops_role.users.all() if success_ops_role \
+            else None
+        if success_ops_members:
+            pending_logged_activities_count = LoggedActivity.query.filter_by(
+                status='pending'
+            ).count()
+            if pending_logged_activities_count:
+                emails_list = []
+                for member in success_ops_members:
+                    emails_list.append(dict(
+                        subject=f'There are pending logged activities',
+                        recipients=[member.email],
+                        message=render_template_string(
+                            SUCCESS_OPS_MESSAGE, name=member.name,
+                            count=pending_logged_activities_count
+                        ),
+                        sender=app.config['NOTIFICATIONS_SENDER']
+                    ))
+                db.session.remove()
+                return True, emails_list
+
+        db.session.remove()
+        return False

--- a/src/app.py
+++ b/src/app.py
@@ -27,7 +27,7 @@ except ImportError:
     from config import configuration
 
 
-def create_app(environment="Development"):
+def create_app(environment="Production"):
     """Factory Method that creates an instance of the app with the given env.
 
     Args:

--- a/src/config.py
+++ b/src/config.py
@@ -26,9 +26,15 @@ class Config(object):
     MAIL_GUN_URL = os.environ.get('MAIL_GUN_URL')
     MAIL_GUN_API_KEY = os.environ.get('MAIL_GUN_API_KEY')
     SENDER_CREDS = os.environ.get("SENDER_CREDS")
+    NOTIFICATIONS_SENDER = os.getenv('NOTIFICATIONS_SENDER')
     CELERY_BACKEND = os.environ.get("CELERY_BACKEND")
     CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL")
     CIO = os.environ.get("CIO")
+
+    SUCCESS_OPS_NEWSLETTER_DAY = os.getenv(
+        'SUCCESS_OPS_NEWSLETTER_DAY', 'mon'
+        # can be int or valid cron day string
+    )
 
 
 class Development(Config):
@@ -52,6 +58,8 @@ class Testing(Config):
     ISSUER = "tests"
     API_IDENTIFIER = "tests"
     MAIL_GUN_TEST = os.environ.get('MAIL_GUN_TEST')
+    NOTIFICATIONS_SENDER = os.getenv('TESTS_NOTIFICATIONS_SENDER',
+                                     'notifications@tests.com')
 
 
 class Staging(Development):

--- a/src/manage.py
+++ b/src/manage.py
@@ -14,7 +14,7 @@ from api.models import Activity, Society, User, db, Center, Role, Cohort
 from app import create_app
 from run_tests import test
 
-app = create_app(environment=os.environ.get('APP_SETTINGS', "Development"))
+app = create_app(environment=os.environ.get('APP_SETTINGS', "Production"))
 manager = Manager(app)
 
 

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -69,11 +69,11 @@ class BaseTestCase(TestCase):
 
     test_successops_payload = {
         "UserInfo": {
-            "email": "test.test@andela.com",
+            "email": "test.successops@andela.com",
             "first_name": "test",
             "id": "-Ktest_id",
             "last_name": "test",
-            "name": "test test",
+            "name": "test success ops",
             "picture": "https://www.link.com",
             "roles": {
                     "Andelan": "-Ktest_andelan_id",

--- a/src/tests/test_activities.py
+++ b/src/tests/test_activities.py
@@ -2,8 +2,7 @@
 import datetime
 import json
 
-from api.models import ActivityType
-from tests.base_test import BaseTestCase
+from .base_test import BaseTestCase, ActivityType
 
 
 class ActivitiesTestCase(BaseTestCase):

--- a/src/tests/test_activity_types.py
+++ b/src/tests/test_activity_types.py
@@ -1,8 +1,7 @@
 """Activity Types Test Suite."""
 import json
 
-from api.models import ActivityType
-from tests.base_test import BaseTestCase
+from .base_test import BaseTestCase, ActivityType
 
 
 class ActivityTypesTestCase(BaseTestCase):

--- a/src/tests/test_add_cohort.py
+++ b/src/tests/test_add_cohort.py
@@ -1,7 +1,8 @@
 """Test adding cohorts and getting cohorts from societies."""
 
 import json
-from tests.base_test import BaseTestCase, Role
+
+from .base_test import BaseTestCase, Role
 
 
 class AddCohortTestCase(BaseTestCase):

--- a/src/tests/test_auth.py
+++ b/src/tests/test_auth.py
@@ -1,5 +1,5 @@
 """Authorization Test Suite."""
-from tests.base_test import BaseTestCase
+from .base_test import BaseTestCase
 
 
 class AuthTestCase(BaseTestCase):

--- a/src/tests/test_logged_activities.py
+++ b/src/tests/test_logged_activities.py
@@ -2,8 +2,7 @@
 import datetime
 import json
 
-from .base_test import BaseTestCase
-from api.models import LoggedActivity
+from .base_test import BaseTestCase, LoggedActivity
 
 
 class LoggedActivitiesTestCase(BaseTestCase):

--- a/src/tests/test_manage.py
+++ b/src/tests/test_manage.py
@@ -1,9 +1,8 @@
 import os
 
-from .base_test import BaseTestCase
-from api.models import ActivityType, Society, db
-from api.utils.initial_data import generete_initial_data_run_time_env
-from manage import seed
+from .base_test import BaseTestCase, ActivityType, Society, db
+from ..api.utils.initial_data import generete_initial_data_run_time_env
+from ..manage import seed
 
 
 class ManagementCommandsTestCase(BaseTestCase):

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -1,9 +1,9 @@
 """Models TestSuite."""
 
-from api.models import (Activity, ActivityType, Cohort, Center,
-                        LoggedActivity, Society, User, Role, RedemptionRequest)
-from tests.base_test import BaseTestCase
-
+from .base_test import (
+    BaseTestCase, Activity, ActivityType, Cohort, Center,
+    LoggedActivity, Society, User, Role, RedemptionRequest
+)
 
 class UserTestCase(BaseTestCase):
     """Test models."""
@@ -12,7 +12,7 @@ class UserTestCase(BaseTestCase):
         """Test we can create user objects."""
         test_user = User(
             uuid="-KdQsMt4M0ixIy_-yWTSZ",
-            name="Test User",
+            name="Test User Model",
             photo="https://lh6.googleusercontent.com/-1DhBLOJentg/AAAAAAAAA"
                   "AI/AAAAAAAAABc/ImM13eP_cAI/photo.jpg?sz=50",
             email="test.user@andela.com",

--- a/src/tests/test_notifications.py
+++ b/src/tests/test_notifications.py
@@ -1,8 +1,8 @@
 """Testing Suite for all notifications."""
 from flask import current_app
 
-from api.utils.notifications.email_notices import send_email
-from tests.base_test import BaseTestCase
+from .base_test import BaseTestCase
+from ..api.utils.notifications.email_notices import send_email
 
 
 class TestMailGunNotification(BaseTestCase):
@@ -16,12 +16,12 @@ class TestMailGunNotification(BaseTestCase):
         email if the email has a subject, message and valid
         recipients email addresses
         """
-        send_email(
+        self.assertTrue(send_email(
             sender=current_app.config["SENDER_CREDS"],
             subject="Test email",
             message="This is a test message",
             recipients=["test.fellow@andela.com"]
-        )
+        ))
 
     def test_send_email_with_invalid_email(self):
         """
@@ -34,6 +34,16 @@ class TestMailGunNotification(BaseTestCase):
             ValueError,
             lambda: send_email(
                 sender=current_app.config["SENDER_CREDS"],
+                subject="Test email",
+                message="This is a test message",
+                recipients=["invalid.gmail.com"]
+            )
+        )
+
+        self.assertRaises(
+            ValueError,
+            lambda: send_email(
+                sender="",
                 subject="Test email",
                 message="This is a test message",
                 recipients=["invalid.gmail.com"]

--- a/src/tests/test_scheduled_tasks.py
+++ b/src/tests/test_scheduled_tasks.py
@@ -1,0 +1,23 @@
+'''Scheduled tasks tests module'''
+from .base_test import BaseTestCase
+from ..api.utils.notifications.email_notices import mail_success_ops
+
+
+class SuccessOpsWeeklyTaskTestCase(BaseTestCase):
+    '''Test app scheduler'''
+
+    def test_that_mail_success_ops_works(self):
+        '''
+        Test that the mail success ops scheduled task works
+        '''
+        self.assertFalse(mail_success_ops(self.app))
+
+        self.successops_role.save()
+        self.client.get(
+            f'/api/v1/logged-activities?paginate=false',
+            headers=self.success_ops
+        )
+        self.log_alibaba_challenge.status = 'pending'
+        self.log_alibaba_challenge.save()
+
+        self.assertTrue(mail_success_ops(self.app)[0])

--- a/src/tests/test_societies.py
+++ b/src/tests/test_societies.py
@@ -1,8 +1,7 @@
 """Test suite for Society Module."""
 import json
 import uuid
-from .base_test import BaseTestCase
-from api.models import Society, Role, db
+from .base_test import BaseTestCase, Society, Role, db
 
 
 class SocietyBaseTestCase(BaseTestCase):

--- a/src/tests/test_task_helpers.py
+++ b/src/tests/test_task_helpers.py
@@ -1,0 +1,51 @@
+'''Module containing tasks helpers tests'''
+from .base_test import BaseTestCase
+from ..api.utils.notifications.task_helpers import \
+    generate_success_ops_pending_activities_emails
+
+
+class HelpersTestCase(BaseTestCase):
+    '''Test Class for helper functions'''
+
+    def test_when_no_succes_ops_role_exists(self):
+        '''Check that no emails are genrated when no success ops role exists'''
+
+        self.assertFalse(
+            generate_success_ops_pending_activities_emails(self.app)
+        )
+
+    def test_when_there_are_no_pending_logged_activities(self):
+        '''
+        Check that no email is generated when there are no pending
+        logged activities
+        '''
+        self.successops_role.save()
+        self.client.get(
+            f'/api/v1/logged-activities?paginate=false',
+            headers=self.success_ops
+        )
+        self.assertFalse(
+            generate_success_ops_pending_activities_emails(self.app)
+        )
+
+    def test_successful_success_ops_mail_generation(self):
+        '''
+        Check that emails are generated when there are pending logged activities
+        '''
+
+        self.successops_role.save()
+        self.client.get(
+            f'/api/v1/logged-activities?paginate=false',
+            headers=self.success_ops
+        )
+        self.log_alibaba_challenge.status = 'pending'
+        self.log_alibaba_challenge.save()
+
+        self.assertTrue(
+            generate_success_ops_pending_activities_emails(self.app)[0]
+        )
+        self.assertIn(
+            self.test_successops_payload['UserInfo']['name'],
+            generate_success_ops_pending_activities_emails(
+                self.app)[1][0]['message']
+        )

--- a/src/tests/test_user_information.py
+++ b/src/tests/test_user_information.py
@@ -4,8 +4,8 @@ from unittest import mock
 
 from flask import Response
 
-from tests.base_test import BaseTestCase, Center, Cohort, Society
-from api.utils.marshmallow_schemas import basic_info_schema
+from .base_test import BaseTestCase, Center, Cohort, Society
+from ..api.utils.marshmallow_schemas import basic_info_schema
 
 
 def info_mock(status_code, society=None, location=None, cohort=None, data=None):


### PR DESCRIPTION
## Resolves #159521293

## Description

  - Success ops members should get a weekly email notification when there are pending logged activities on the platform.
- Initially, logged activities would get approved but the respective society's total points weren't incremented.
- Celery failed to work without a flask app context.

## Fix

  - There is now a scheduled weekly job that gets the count of all pending logged activities and emails success ops members.
- There's a new line in the _approve logged activities by success ops_ endpoint that increments a society's total points during approval.
 - **Other fixes**:
    - Set default environment to production
    - Prevent creating a redemption request when society has insufficient 
remaining points
    - Update notifications package to have its own flask instance for use with celery tasks
    - Update and fix the `Role` to `User` many to many relationship
    - Add html support for emails
    - Update all tests files to support single file tests via the `pytest` command
 

## How to test (describe how to test your PR)

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.
- Run `pytest tests/test_task_helpers.py tests/test_scheduled_tasks.py -v` at the root of the src directory
