### PR TITLE
#159668684 Reject a logged activity

### DIFF
--- a/src/api/endpoints/logged_activities.py
+++ b/src/api/endpoints/logged_activities.py
@@ -309,3 +309,41 @@ class LoggedActivityApprovalAPI(Resource):
             return response_builder(dict(
                                 message='Data for creation must be provided.'),
                                 400)
+
+
+class LoggedActivityRejectionAPI(Resource):
+    """Allows success-ops to reject at least one Logged Activities."""
+
+    decorators = [token_required]
+
+    @classmethod
+    @roles_required(["success ops"])
+    def put(cls, logged_activity_id):
+        """Put method for rejecting logged activity resource."""
+
+        logged_activity = LoggedActivity.query.filter_by(
+            uuid=logged_activity_id).first()
+
+        if not logged_activity:
+            return response_builder(dict(message='Logged activity not found'),
+                                    404)
+
+        if logged_activity.status == 'pending':
+            logged_activity.status = 'rejected'
+
+            user_logged_activity = single_logged_activity_schema.dump(logged_activity).data
+            user_logged_activity['society'] = {'id': user_logged_activity['societyId'],
+                    'name': user_logged_activity['society']}
+            del user_logged_activity['societyId']
+
+            return response_builder(dict(
+                    data=user_logged_activity,
+                    message='Activity successfully rejected'),
+                    200)
+        else:
+            return response_builder(dict(
+                    status='failed',
+                    message='This logged activity is either in-review, approved or already rejected'
+                    ),
+                    406)
+

--- a/src/app.py
+++ b/src/app.py
@@ -15,7 +15,8 @@ from api.endpoints.logged_activities import (UserLoggedActivitiesAPI,
                                              SecretaryReviewLoggedAcivityApi)
 from api.endpoints.logged_activities import LoggedActivitiesAPI
 from api.endpoints.logged_activities import LoggedActivityAPI
-from api.endpoints.logged_activities import LoggedActivityApprovalAPI
+from api.endpoints.logged_activities import (LoggedActivityApprovalAPI,
+                                             LoggedActivityRejectionAPI)
 from api.endpoints.roles import RoleAPI, SocietyRoleAPI
 from api.models import db
 
@@ -161,9 +162,15 @@ def create_app(environment="Development"):
     )
 
     api.add_resource(LoggedActivityApprovalAPI,
-        "/api/v1/approve/logged-activities",
-        "/api/v1/approve/logged-activities/",
+        "/api/v1/logged-activities/approve",
+        "/api/v1/logged-activities/approve/",
         endpoint="approve_logged_activities"
+    )
+
+    api.add_resource(LoggedActivityRejectionAPI,
+        "/api/v1/logged-activity/reject/<string:logged_activity_id>",
+        "/api/v1/logged-activity/reject/<string:logged_activity_id>/",
+        endpoint="reject_logged_activity"
     )
 
     # enable health check ping to API

--- a/src/tests/test_logged_activities.py
+++ b/src/tests/test_logged_activities.py
@@ -537,7 +537,7 @@ class LoggedActivityApprovalTestCase(BaseTestCase):
         )
 
         response = self.client.put(
-           f'/api/v1/approve/logged-activities',
+           f'/api/v1/logged-activities/approve/',
            data=json.dumps(self.payload),
            headers=self.success_ops
         )
@@ -568,7 +568,7 @@ class LoggedActivityApprovalTestCase(BaseTestCase):
         )
 
         response = self.client.put(
-           f'/api/v1/approve/logged-activities',
+           f'/api/v1/logged-activities/approve/',
            data=json.dumps(self.payload),
            headers=self.header
         )
@@ -594,7 +594,7 @@ class LoggedActivityApprovalTestCase(BaseTestCase):
         )
 
         response = self.client.put(
-           '/api/v1/approve/logged-activities',
+           '/api/v1/logged-activities/approve/',
            headers=self.success_ops
         )
 
@@ -618,7 +618,7 @@ class LoggedActivityApprovalTestCase(BaseTestCase):
         )
 
         response = self.client.put(
-           f'/api/v1/approve/logged-activities',
+           f'/api/v1/logged-activities/approve/',
            data=json.dumps(self.payload),
            headers=self.success_ops
         )
@@ -644,7 +644,7 @@ class LoggedActivityApprovalTestCase(BaseTestCase):
         )
 
         response = self.client.put(
-           f'/api/v1/approve/logged-activities',
+           f'/api/v1/logged-activities/approve/',
            data=json.dumps(self.payload),
            headers=self.success_ops
         )
@@ -671,7 +671,7 @@ class LoggedActivityApprovalTestCase(BaseTestCase):
         )
 
         response = self.client.put(
-           f'/api/v1/approve/logged-activities',
+           f'/api/v1/logged-activities/approve/',
            data=json.dumps(self.payload),
            headers=self.success_ops
         )
@@ -682,6 +682,76 @@ class LoggedActivityApprovalTestCase(BaseTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response_details['message'], message)
 
+
+class LoggedActivityRejectTestCase(BaseTestCase):
+    """Test to check rejection of Logged activities by success ops"""
+
+
+    def test_reject_logged_activities_successful(self):
+
+        """
+        Test a scenario where rejection of a logged activity passes
+        if the user is a successops.
+        """
+
+        self.successops_role.save()
+        self.log_alibaba_challenge.status = 'pending'
+        self.log_alibaba_challenge.save()
+
+        response = self.client.put(
+           f'/api/v1/logged-activity/reject/{self.log_alibaba_challenge.uuid}',
+           headers=self.success_ops
+        )
+
+        message = 'Activity successfully rejected'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_details['message'], message)
+        self.assertEqual(response_details['data']['status'], 'rejected')
+
+
+    def test_reject_invalid_logged_activities_unsuccessful(self):
+
+        """
+        Test a scenario where rejection of a logged activity fails
+        if logged activity doesn't exit.
+        """
+
+        self.successops_role.save()
+
+        response = self.client.put(
+           '/api/v1/logged-activity/reject/43kaa',
+           headers=self.success_ops
+        )
+
+        message = 'Logged activity not found'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response_details['message'], message)
+
+    def test_reject_non_pending_logged_activities_unsuccessful(self):
+
+        """
+        Test a scenario where rejection of a logged activity fails
+        if logged activity status is not pending.
+        """
+
+        self.successops_role.save()
+        self.log_alibaba_challenge.status = 'rejected'
+        self.log_alibaba_challenge.save()
+
+        response = self.client.put(
+           f'/api/v1/logged-activity/reject/{self.log_alibaba_challenge.uuid}',
+           headers=self.success_ops
+        )
+
+        message = 'This logged activity is either in-review, approved or already rejected'
+        response_details = json.loads(response.get_data(as_text=True))
+
+        self.assertEqual(response.status_code, 406)
+        self.assertEqual(response_details['message'], message)
 
 class DeleteLoggedActivityTestCase(BaseTestCase):
     """Delete logged activity test cases."""


### PR DESCRIPTION
#### Description (what problem you're fixing)
- Allow a success-ops user reject a logged activity.

#### Fix (what you did to fix it)
 - Implement endpoint to allow success-ops reject a logged activity.

#### How to test (describe how to test your PR)
- Clone the repository, install docker and rabbitmq-app, run `run_tests.py` within the repository.
- Trigger a build on CircleCI.