### PR TITLE
Refactor society secretary approval-rejection endpoint

### DIFF
--- a/src/api/endpoints/logged_activities.py
+++ b/src/api/endpoints/logged_activities.py
@@ -212,7 +212,7 @@ class LoggedActivityAPI(Resource):
         return response_builder(dict(), 204)
 
 
-class SecretaryReviewLoggedAcivityApi(Resource):
+class SecretaryReviewLoggedActivityApi(Resource):
     """Enable society secretary to verify logged activities."""
 
     decorators = [token_required]

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -93,8 +93,11 @@ class Base(db.Model):
             A dict object
         """
         dictionary_mapping = {
-            camel_case(attribute.name): str(getattr(self, attribute.name))
-            for attribute in self.__table__.columns}
+            camel_case(attribute.name): str(getattr(self, attribute.name)) \
+            if not isinstance(getattr(self, attribute.name), int) \
+            else getattr(self, attribute.name) \
+            for attribute in self.__table__.columns
+        }
         return dictionary_mapping
 
 

--- a/src/api/utils/marshmallow_schemas.py
+++ b/src/api/utils/marshmallow_schemas.py
@@ -83,6 +83,7 @@ class LoggedActivitySchema(BaseSchema):
     points = fields.Integer(attribute='value')
     date = fields.Date(attribute='activity_date', dump_to='activityDate', load_from='activityDate')
     owner = fields.String(attribute='user.name')
+    owner_photo = fields.Url(attribute='user.photo')
     activity_id = fields.String(dump_to='activityId', load_from='activityId')
     activity = fields.String(attribute='activity.name')
     category = fields.String(attribute='activity_type.name')
@@ -240,17 +241,13 @@ class CohortSchema(BaseSchema):
 class SocietySchema(BaseSchema):
     """Validation/Serialize Schema for Society."""
 
-    _total_points = fields.String(dump_only=True, dump_to='totalPoints',
-                                  validate=[validate.Length(max=36)])
+    _total_points = fields.Integer(dump_only=True, dump_to='totalPoints')
 
-    _used_points = fields.String(dump_only=True, dump_to='usedPoints',
-                                 validate=[validate.Length(max=36)])
+    _used_points = fields.Integer(dump_only=True, dump_to='usedPoints')
 
-    remaining_points = fields.String(dump_only=True, dump_to='remainingPoints',
-                                     validate=[validate.Length(max=36)])
+    remaining_points = fields.Integer(dump_only=True, dump_to='remainingPoints')
 
-    color_scheme = fields.String(dump_only=True, dump_to='colorScheme',
-                                 validate=[validate.Length(max=36)])
+    color_scheme = fields.String(dump_only=True, dump_to='colorScheme')
 
 
 class UserSchema(BaseSchema):
@@ -291,8 +288,7 @@ class RedemptionSchema(BaseSchema):
 
     status = fields.String(dump_only=True, dump_to='status',
                            validate=[validate.Length(max=36)])
-    value = fields.Integer(dump_only=True, dump_to='value',
-                           validate=[validate.Length(max=36)])
+    value = fields.Integer(dump_only=True, dump_to='value')
 
 
 activity_types_schema = ActivityTypesSchema(many=True)

--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,7 @@ from api.endpoints.redemption_requests import RedemptionRequestNumeration
 from api.endpoints.redemption_requests import RedemptionRequestFunds
 from api.endpoints.users import UserAPI
 from api.endpoints.logged_activities import (UserLoggedActivitiesAPI,
-                                             SecretaryReviewLoggedAcivityApi)
+                                             SecretaryReviewLoggedActivityApi)
 from api.endpoints.logged_activities import LoggedActivitiesAPI
 from api.endpoints.logged_activities import LoggedActivityAPI
 from api.endpoints.logged_activities import (LoggedActivityApprovalAPI,
@@ -86,9 +86,9 @@ def create_app(environment="Production"):
 
     # society secretary logged Activity endpoint
     api.add_resource(
-        SecretaryReviewLoggedAcivityApi,
-        '/api/v1/logged-activity/verify/<string:logged_activity_id>',
-        '/api/v1/logged-activity/verify/<string:logged_activity_id>/',
+        SecretaryReviewLoggedActivityApi,
+        '/api/v1/logged-activities/review/<string:logged_activity_id>',
+        '/api/v1/logged-activities/review/<string:logged_activity_id>/',
         endpoint='secretary_logged_activity'
     )
 

--- a/src/tests/test_logged_activities.py
+++ b/src/tests/test_logged_activities.py
@@ -447,7 +447,7 @@ class EditLoggedActivityTestCase(BaseTestCase):
         payload = {'status': 'pending'}
         uuid = self.log_alibaba_challenge.uuid
         response = self.client.put(
-            f'/api/v1/logged-activity/verify/{uuid}',
+            f'/api/v1/logged-activities/review/{uuid}',
             data=json.dumps(payload),
             headers=self.society_secretary
         )
@@ -462,7 +462,7 @@ class EditLoggedActivityTestCase(BaseTestCase):
         uuid = self.log_alibaba_challenge.uuid
 
         response = self.client.put(
-            f'/api/v1/logged-activity/verify/{uuid}',
+            f'/api/v1/logged-activities/review/{uuid}',
             data=json.dumps(payload),
             headers=self.society_secretary
         )
@@ -477,7 +477,7 @@ class EditLoggedActivityTestCase(BaseTestCase):
         payload = {'status': 'invalid'}
         uuid = self.log_alibaba_challenge.uuid
         response = self.client.put(
-            f'/api/v1/logged-activity/verify/{uuid}',
+            f'/api/v1/logged-activities/review/{uuid}',
             data=json.dumps(payload),
             headers=self.society_secretary
         )
@@ -489,7 +489,7 @@ class EditLoggedActivityTestCase(BaseTestCase):
         payload = {'status': 'invalid'}
 
         response = self.client.put(
-            f'/api/v1/logged-activity/verify/-KlHerwfafcvavefa',
+            '/api/v1/logged-activities/review/-KlHerwfafcvavefa',
             data=json.dumps(payload),
             headers=self.society_secretary
         )
@@ -504,7 +504,7 @@ class EditLoggedActivityTestCase(BaseTestCase):
         payload = {}
 
         response = self.client.put(
-            f'/api/v1/logged-activity/verify/-KlHerwfafcvavefa',
+            '/api/v1/logged-activities/review/-KlHerwfafcvavefa',
             data=json.dumps(payload),
             headers=self.society_secretary
         )


### PR DESCRIPTION
## Resolves #159786516

## Description

  - Logged activities do not contain the owner's photo URL
  - The secretary review endpoint is different from what's documented on Apiary
  - The frontend currently gets integer values as strings

## Fixes

  - Add owner photo to logged activities fields
  - Update models serialize method to ignore stringifying integers
  - Update Marshmallow Schema fields to match corresponding column types on the DB
  - Refactor secretary verify activity tests

## How to test (describe how to test your PR)

- Clone the repository, install Docker, run `make test` within the repository.
- Trigger a build on CircleCI.
- Run the command `python run_tests.py` at the root of the `src` directory
