### PR TITLE
[ft #159521316] Send Email Notification to Finance When Redemption Request is Approved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ target/
 .python-version
 
 # celery beat schedule file
-celerybeat-schedule
+celerybeat-schedule.db
 
 # SageMath parsed files
 *.sage.py
@@ -115,3 +115,6 @@ ENV/
 
 migrations/*
 .envrc
+
+.idea/
+.idea

--- a/src/api/endpoints/redemption_requests.py
+++ b/src/api/endpoints/redemption_requests.py
@@ -127,7 +127,7 @@ class PointRedemptionAPI(Resource):
 
     @classmethod
     @token_required
-    @roles_required(["cio", "society president", "vice president",
+    @roles_required(["finance", "cio", "society president", "vice president",
                      "secretary"])
     def get(cls, redeem_id=None):
         """Get Redemption Requests."""
@@ -251,10 +251,20 @@ class RedemptionRequestNumeration(Resource):
             send_email.delay(
                 sender=current_app.config["SENDER_CREDS"],
                 subject="RedemptionRequest for {}".format(
+                    redemp_request.user.society.name),
+                message="Redemption Request on {} has been approved. Click the link below"
+                        " <a href='{}'>here</a> to view more details.".format(
+                    redemp_request.name, request.host_url + 'api/v1/societies/redeem/' + redeem_id),
+                recipients=[finance_email]
+            )
+
+            send_email.delay(
+                sender=current_app.config["SENDER_CREDS"],
+                subject="RedemptionRequest for {}".format(
                                     redemp_request.user.society.name),
                 message="Redemption Request on {} has been approved. Finance"
                 " will be in touch.".format(redemp_request.name),
-                recipients=[redemp_request.user.email, finance_email]
+                recipients=[redemp_request.user.email]
             )
 
         elif status == "rejected":

--- a/src/tests/test_redemption_requests.py
+++ b/src/tests/test_redemption_requests.py
@@ -440,6 +440,34 @@ class PointRedemptionApprovalTestCase(BaseTestCase):
         self.assertIn(message, response_details["message"])
         self.assertEqual(response.status_code, 200)
 
+    def test_get_non_existing_point_redemption_details_by_finance(self):
+        """Test retrieval of Redemption Requests."""
+        response = self.client.get(
+                        f"api/v1/societies/redeem/{str(uuid.uuid4())}",
+                        headers=self.finance,
+                        content_type='application/json')
+        message = "does not exist"
+        response_details = json.loads(response.data)
+
+        self.assertIn(message, response_details["message"])
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_point_redemption_details_by_finance(self):
+        """Test view of RedemptionRequest by finance.
+        """
+
+        response = self.client.get(
+                    f"api/v1/societies/redeem/{self.redemp_req.uuid}",
+                    headers=self.finance,
+                    content_type='application/json'
+        )
+
+        message = "fetched successfully"
+        response_details = json.loads(response.data)
+
+        self.assertIn(message, response_details["message"])
+        self.assertEqual(response.status_code, 200)
+
     def test_point_redemption_completion_successful(self):
         """Test completion of RedemptionRequest.
 


### PR DESCRIPTION
## Resolves #159521316

## Description (what problem you're fixing)
- Implement email notification to finance with link to view details when redemption request is approved

## Fix (what you did to fix it)
- Refactor redemption request approval endpoint to send email to finance with link to view details
- Add finance role to GET endpoint `api/v1/societies/redeem/<:redeem_id>` 
- write test

## How to test (describe how to test your PR)

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.
- run `python manage.py tests` from the `src` directory
