### PR TITLE
#160418381 Deploy staging from the develop branch 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,14 +65,14 @@ workflows:
           filters:
             branches:
               only:
-                - staging
+                - develop
       - deploy-staging:
           requires:
             - upgrade-database
           filters:
             branches:
               only:
-                - staging
+                - develop
       - deploy-master:
           requires:
             - test

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,12 +6,12 @@ set_variables() {
     COMMIT_HASH=$(git rev-parse --short HEAD)
 
     if [ "$CIRCLE_BRANCH" == 'master' ]; then
-        IMAGE_TAG=$COMMIT_HASH
+        IMAGE_TAG="production-${COMMIT_HASH}"
         ENVIRONMENT=production
         GOOGLE_COMPUTE_ZONE=${PRODUCTION_ZONE}
         GOOGLE_CLUSTER_NAME=${PRODUCTION_CLUSTER_NAME}
     else
-        IMAGE_TAG="${CIRCLE_BRANCH}-${COMMIT_HASH}"
+        IMAGE_TAG="staging-${COMMIT_HASH}"
         ENVIRONMENT=staging
         GOOGLE_COMPUTE_ZONE=${STAGING_ZONE}
         GOOGLE_CLUSTER_NAME=${STAGING_CLUSTER_NAME}


### PR DESCRIPTION
## Resolves #160418381

## Description (what problem you're fixing)
This P.R. :
* Changes the branch, responsible for deploying to staging, to *develop* branch.
* Changes the format of tagging the docker images. 

## Fix (what you did to fix it)
- Changed deployment configuration for staging to be deployed from the develop branch.
- Changed the mode of tagging container images to use their respective environments.

## How to test (describe how to test your PR)
Merges made to master an develop branch should deploy to production and staging respectively.