### PR TITLE
[Bug #160789232] Fix secretary logged activities view permission bug.

### DIFF
--- a/src/api/endpoints/logged_activities/secretary_review.py
+++ b/src/api/endpoints/logged_activities/secretary_review.py
@@ -1,5 +1,5 @@
 from flask_restful import Resource
-from flask import request
+from flask import request, g
 
 from api.services.auth import token_required, roles_required
 from api.utils.helpers import response_builder
@@ -30,6 +30,13 @@ class SecretaryReviewLoggedActivityAPI(Resource):
         if not logged_activity:
             return response_builder(dict(message='Logged activity not found'),
                                     404)
+
+        if logged_activity.society.uuid != g.current_user.society.uuid:
+            society = logged_activity.society.name
+            return response_builder(dict(
+                message=f"Permission denied, you are not a secretary of {society}"
+                ),
+                403)
 
         if not (payload.get('status') in ['pending', 'rejected']):
             return response_builder(dict(message='Invalid status value.'),

--- a/src/api/endpoints/redemption_requests/helpers.py
+++ b/src/api/endpoints/redemption_requests/helpers.py
@@ -29,7 +29,7 @@ def get_redemption_request(redeem_id):
 
 
 def serialize_redmp(redemption):
-    """To serialize and package redeptions."""
+    """To serialize and package redemptions."""
     serial_data, _ = redemption_schema.dump(redemption)
     seriallized_user, _ = basic_info_schema.dump(redemption.user)
     serilaized_society, _ = basic_info_schema.dump(redemption.user.society)
@@ -37,3 +37,23 @@ def serialize_redmp(redemption):
     serial_data["society"] = serilaized_society
     serial_data["center"], _ = basic_info_schema.dump(redemption.center)
     return serial_data
+
+
+def serialize_redemptions(redemptions):
+    """To serialize a list of redemptions."""
+    return map(serialize_redmp, redemptions)
+
+
+def non_paginated_redemptions(redemptions):
+    """To package a list of serialized redemptions."""
+    data = list(serialize_redemptions(redemptions))
+    return dict(
+        message="fetched successfully.",
+        pages=1,
+        previousUrl=None,
+        nextUrl=None,
+        status="success",
+        count=len(data),
+        currentPage=1,
+        data=data
+    )

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -428,7 +428,7 @@ class BaseTestCase(TestCase):
             value=2500,
             user=self.test_user,
             activity=self.alibaba_ai_challenge,
-            society=self.phoenix,
+            society=self.invictus,
             activity_type=self.hackathon
         )
 

--- a/src/tests/test_model.py
+++ b/src/tests/test_model.py
@@ -138,8 +138,8 @@ class SocietyTestCase(BaseTestCase):
 
     def test_delete_existing_society(self):
         """Test if society has been deleted successfully."""
-        self.invictus.save()
-        self.assertTrue(self.invictus.delete())
+        self.istelle.save()
+        self.assertTrue(self.istelle.delete())
 
     def test_delete_nonexistent_society(self):
         """Test for false return if nonexistent society is deleted."""
@@ -212,7 +212,7 @@ class LoggedActivityTestCase(BaseTestCase):
         self.log_alibaba_challenge.save()
 
         self.assertListEqual(
-            self.phoenix.logged_activities.all(), [self.log_alibaba_challenge]
+            self.invictus.logged_activities.all(), [self.log_alibaba_challenge]
         )
 
 

--- a/src/tests/test_redemption_requests.py
+++ b/src/tests/test_redemption_requests.py
@@ -127,7 +127,7 @@ class PointRedemptionBaseTestCase(BaseTestCase):
 
     def test_get_all_redemption_requests_by_cio(self):
         """Test retrieval of Redemption Requests."""
-        response = self.client.get("api/v1/societies/redeem",
+        response = self.client.get("api/v1/societies/redeem?paginate=false",
                                    headers=self.cio,
                                    content_type='application/json')
 


### PR DESCRIPTION
## Resolves #160789232

## Description (what problem you're fixing)

  - Secretaries should only be able to review logged activities in there societies. 
 

## Fix (what you did to fix it)

  - Add a check to make sure the secretary belongs to the said society that the logged activity belongs to. 
  

## How to test (describe how to test your PR)

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.
