### PR TITLE
#161539722 Create success and failure notifications for develop and master builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,20 @@ jobs:
           name: upgrade database
           command: |
             bash scripts/upgrade.sh
+      - run:
+          name: Build Success
+          when: on_success
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+                bash scripts/slack_notification.sh "Staging database was upgraded successfully" "good"
+            fi
+      - run:
+          name: Build Failed
+          when: on_fail
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+                bash scripts/slack_notification.sh "Staging database upgrade failed!!!" "danger"
+            fi
 
   deploy-staging:
     <<: *defaults
@@ -42,6 +56,20 @@ jobs:
           name: deploy application
           command: |
             bash scripts/deploy.sh
+      - run:
+          name: Build Success
+          when: on_success
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+                bash scripts/slack_notification.sh "The develop branch has been deployed to the staging environment" "good"
+            fi
+      - run:
+          name: Build Failed
+          when: on_fail
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+                bash scripts/slack_notification.sh "Deployment to staging failed!!!" "danger"
+            fi
 
   deploy-master:
     <<: *defaults
@@ -53,6 +81,20 @@ jobs:
           name: deploy application
           command: |
             bash scripts/deploy.sh
+      - run:
+          name: Build Success
+          when: on_success
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+                bash scripts/slack_notification.sh "The master branch has been deployed to the production environment" "good"
+            fi
+      - run:
+          name: Build Failed
+          when: on_fail
+          command: |
+            if [ "$CIRCLE_NODE_INDEX" == 0 ]; then
+                bash scripts/slack_notification.sh "Deployment to production failed!!!" "danger"
+            fi
 
 workflows:
   version: 2

--- a/scripts/slack_notification.sh
+++ b/scripts/slack_notification.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+
+declare_env_variables() {
+
+  # Declaring environment variables
+  #
+  # Some environment variables assigned externally are:
+  # SLACK_CHANNEL_HOOK : This is the webhook for the Slack App where notifications will be sent from
+  # DEPLOYMENT_CHANNEL : This is the channel on which the Slack notifications will be posted
+  # MESSAGE_TEXT: The text to be sent to the slack channel
+  # Some template for the Slack message
+  MESSAGE_TEXT="$1"
+  MESSAGE_COLOR="$2"
+
+  COMMIT_LINK="https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}"
+  IMG_TAG="$(git rev-parse --short HEAD)"
+  CIRCLE_WORKFLOW_URL="https://circleci.com/workflow-run/${CIRCLE_WORKFLOW_ID}"
+  SLACK_TEXT_TITLE="CircleCI Build #$CIRCLE_BUILD_NUM"
+  SLACK_DEPLOYMENT_TEXT="Executed Git Commit <$COMMIT_LINK|${IMG_TAG}>: ${MESSAGE_TEXT}"
+}
+
+send_notification() {
+
+  # Sending the Slack notification
+
+  curl -X POST --data-urlencode \
+  "payload={
+      \"channel\": \"${DEPLOYMENT_CHANNEL}\",
+      \"username\": \"JobNotification\",
+      \"attachments\": [{
+          \"fallback\": \"CircleCI job notification\",
+          \"color\": \"${MESSAGE_COLOR}\",
+          \"author_name\": \"Branch: $CIRCLE_BRANCH by ${CIRCLE_USERNAME}\",
+          \"author_link\": \"https://github.com/AndelaOSP/andela-societies-backend/tree/${CIRCLE_BRANCH}\",
+          \"title\": \"${SLACK_TEXT_TITLE}\",
+          \"title_link\": \"$CIRCLE_WORKFLOW_URL\",
+          \"text\": \"${SLACK_DEPLOYMENT_TEXT}\"
+      }]
+  }" \
+  "${SLACK_CHANNEL_HOOK}"
+}
+
+main() {
+  echo "Declaring environment variables"
+  declare_env_variables "$@"
+
+  echo "Sending notification"
+  send_notification
+}
+
+main "$@"


### PR DESCRIPTION
## Resolves #161539722

## Description (what problem you're fixing)
  - Pushes on develop and master involve builds that affect infrastructure on GCP. Developers may not have access to view the resource on GCP but it would be better to get customized messages on what happened to the steps that affect the infrastructure on GCP.

## Fix (what you did to fix it)

- Notifications will now be sent to the #societies-dev-connect page after either a successful or failed run for builds that affect the infrastructure on GCP on circle CI.

## Screenshots 
- Ignore the branch naming in the screenshots.
* Deployments to Production: Fail and Success Notification
![image](https://user-images.githubusercontent.com/29925144/47994551-aab5e900-e103-11e8-8ff4-32baa88520fe.png)


* Deployments to Staging: Fail and Success Notification
![image](https://user-images.githubusercontent.com/29925144/47994470-662a4d80-e103-11e8-83ed-52dd924f5e58.png)

* Upgrading the staging database: Fail and Success Notification
![image](https://user-images.githubusercontent.com/29925144/47994440-485ce880-e103-11e8-9f59-5ac841397cbe.png)
