### PR TITLE
#162497543 Create a CD pipeline for the MVP2 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,3 +92,4 @@ workflows:
               only:
                 - develop
                 - master
+                - design


### PR DESCRIPTION
## Resolves #162497543

## Description (what problem you're fixing)

  - The developers need a new environment to work on their MVP 2 that will involve refactoring previous code.
  -  In consideration to the need above it was necessary to still utilise the resource we have efficiently on GCP.

## Fix (what you did to fix it)

  - Created a pipeline that can be deployed by the design branch
  - Ensured that this pipeline would point to the staging cluster on GCP

## How to test (describe how to test your PR)

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.
