### PR TITLE
#163219885 Notify secretary when points are logged

### DIFF
--- a/src/api/endpoints/logged_activities/crud.py
+++ b/src/api/endpoints/logged_activities/crud.py
@@ -23,6 +23,7 @@ class LoggedActivitiesAPI(Resource, SlackNotification):
         self.ActivityType = kwargs['ActivityType']
         self.LoggedActivity = kwargs['LoggedActivity']
         SlackNotification.__init__(self)
+        # self.all_users = User.query.all()
 
     def post(self):
         """Log a new activity."""
@@ -79,6 +80,8 @@ class LoggedActivitiesAPI(Resource, SlackNotification):
             #send notification to the society secretary about logged points
 
             roles = User.query.filter(User.roles.any(Role.name=="society secretary")).all()
+            # for user in self.all_users:
+            #     users = filter(lambda x: x.society_id==society_id, self.all_users)
             users = User.query.filter_by(society_id=society_id).all()
             message = "New activities logged. Go to https://societies.andela.com to approve points"
             for role in roles:
@@ -86,8 +89,6 @@ class LoggedActivitiesAPI(Resource, SlackNotification):
                     user_email = role.email
                     slack_id = SlackNotification.get_slack_id(self, user_email)
                     SlackNotification.send_message(self, message, slack_id)
-                else:
-                    pass
 
             return response_builder(dict(
                 data=single_logged_activity_schema.dump(logged_activity).data,

--- a/src/api/endpoints/logged_activities/crud.py
+++ b/src/api/endpoints/logged_activities/crud.py
@@ -77,6 +77,8 @@ class LoggedActivitiesAPI(Resource, SlackNotification):
             
             society_id = g.current_user.society_id
 
+            #send notification to the society secretary about logged points
+
             roles = User.query.filter(User.roles.any(Role.name=="society secretary")).all()
             users = User.query.filter_by(society_id=society_id).all()
             message = "New activities logged. Go to https://societies.andela.com to approve points"
@@ -85,7 +87,6 @@ class LoggedActivitiesAPI(Resource, SlackNotification):
                     user_email = role.email
                     slack_id = SlackNotification.get_slack_id(self, user_email)
                     SlackNotification.send_message(self, message, slack_id)
-                    print("the user is", user_email)
                 else:
                     pass
 

--- a/src/api/endpoints/logged_activities/crud.py
+++ b/src/api/endpoints/logged_activities/crud.py
@@ -9,7 +9,7 @@ from .marshmallow_schemas import (
     LogEditActivitySchema, single_logged_activity_schema,
     logged_activities_schema
 )
-
+from api.models import Role, User, Society
 
 class LoggedActivitiesAPI(Resource):
     """Logged Activities Resources."""
@@ -72,6 +72,12 @@ class LoggedActivitiesAPI(Resource):
                     ]
 
             logged_activity.save()
+            
+            society_id = g.current_user.society_id
+            roles = Role.query.filter_by(Role.users.user_role.any(name="secretary")).all()
+            # society_query = Society.query.all()
+            print(roles)
+
 
             return response_builder(dict(
                 data=single_logged_activity_schema.dump(logged_activity).data,

--- a/src/api/endpoints/logged_activities/crud.py
+++ b/src/api/endpoints/logged_activities/crud.py
@@ -89,7 +89,6 @@ class LoggedActivitiesAPI(Resource, SlackNotification):
                 else:
                     pass
 
-
             return response_builder(dict(
                 data=single_logged_activity_schema.dump(logged_activity).data,
                 message='Activity logged successfully'

--- a/src/api/endpoints/logged_activities/crud.py
+++ b/src/api/endpoints/logged_activities/crud.py
@@ -10,7 +10,7 @@ from .marshmallow_schemas import (
     LogEditActivitySchema, single_logged_activity_schema,
     logged_activities_schema
 )
-from api.models import Role, User, Society
+from api.models import Role, User
 
 class LoggedActivitiesAPI(Resource, SlackNotification):
     """Logged Activities Resources."""
@@ -74,7 +74,6 @@ class LoggedActivitiesAPI(Resource, SlackNotification):
                     ]
 
             logged_activity.save()
-            
             society_id = g.current_user.society_id
 
             #send notification to the society secretary about logged points

--- a/src/api/endpoints/logged_activities/crud.py
+++ b/src/api/endpoints/logged_activities/crud.py
@@ -70,12 +70,19 @@ class LoggedActivitiesAPI(Resource):
                     logged_activity.no_of_participants = result[
                         'no_of_participants'
                     ]
+            # query = User.db.session.query(User).join(Role, Role.name == 'society secretary')
+            # print(query.all())
 
-            logged_activity.save()
+            # logged_activity.save()
             
             society_id = g.current_user.society_id
-            roles = Role.query.filter_by(Role.users.user_role.any(name="secretary")).all()
+            # roles = Role.query.filter_by(Role.users.user_role.any(name="secretary")).all()
+            # roles = Role.query.join(User).order_by(UserRole.name)
             # society_query = Society.query.all()
+            query = User.query.join(Role)
+            roles = query.order_by(User.roles).all()
+
+            # query = User.query(User).join(User.roles).join(Role.name)
             print(roles)
 
 

--- a/src/api/services/auth/auth.py
+++ b/src/api/services/auth/auth.py
@@ -76,7 +76,6 @@ def token_required(f):
             return response_builder(dict(message="malformed token"), 401)
         else:
             user = User.query.get(payload["UserInfo"]["id"])  #TODO check if user id exists
-            print("user id is>>>>", user)
             # user id returns the name of the user
             if not user:
                 user = store_user_details(payload, authorization_token)

--- a/src/api/services/auth/helpers.py
+++ b/src/api/services/auth/helpers.py
@@ -59,7 +59,6 @@ def store_user_details(payload, token):
     roles = payload["UserInfo"]["roles"]
 
     user = User.query.get(user_id)
-    print("this is the new print", user)
     # save user to db if they haven't been saved yet
     if not user:
         user = User(

--- a/src/api/services/slack-notify/notification.py
+++ b/src/api/services/slack-notify/notification.py
@@ -1,0 +1,44 @@
+import os
+import logging
+
+from slackclient import SlackClient
+
+
+class SlackNotification(object):
+
+    def __init__(self):
+        slack_token = os.getenv('SLACK_API_TOKEN')
+        if slack_token:
+            self.sc = SlackClient(slack_token)
+
+
+
+    def get_slack_id(self, user):
+        user_email = user.email
+        results = sc.api_call("users.list")
+        users = results.get("members")
+
+        if users:
+            user_id = [
+                user.get("id")
+                for user in users
+                if user.get("profile").get("email") == user_email
+            ]
+
+        try:
+            return user_id[0]
+        except Exception:
+            logging.info("User not found")
+            return None
+
+
+    def send_message(self, message, slack_id):
+        sc.api_call(
+            "chat.postEphemeral",
+            channel=slack_id,
+            text=message,
+            username='@notifier',
+            user=slack_id,
+            as_user=True,
+            icon_emoji=':ninja:',
+        )

--- a/src/api/services/slack_notify/__init__.py
+++ b/src/api/services/slack_notify/__init__.py
@@ -1,0 +1,1 @@
+from api.services.slack_notify.notification import SlackNotification

--- a/src/api/services/slack_notify/notification.py
+++ b/src/api/services/slack_notify/notification.py
@@ -8,7 +8,6 @@ class SlackNotification(object):
 
     def __init__(self):
         slack_token = os.getenv('SLACK_API_TOKEN')
-        print(slack_token)
         if slack_token:
             self.sc = SlackClient(slack_token)
 

--- a/src/api/services/slack_notify/notification.py
+++ b/src/api/services/slack_notify/notification.py
@@ -10,8 +10,6 @@ class SlackNotification(object):
         slack_token = os.getenv('SLACK_API_TOKEN')
         if slack_token:
             self.sc = SlackClient(slack_token)
-        else:
-            pass
 
 
 

--- a/src/api/services/slack_notify/notification.py
+++ b/src/api/services/slack_notify/notification.py
@@ -10,6 +10,8 @@ class SlackNotification(object):
         slack_token = os.getenv('SLACK_API_TOKEN')
         if slack_token:
             self.sc = SlackClient(slack_token)
+        else:
+            pass
 
 
 

--- a/src/api/services/slack_notify/notification.py
+++ b/src/api/services/slack_notify/notification.py
@@ -8,14 +8,15 @@ class SlackNotification(object):
 
     def __init__(self):
         slack_token = os.getenv('SLACK_API_TOKEN')
+        print(slack_token)
         if slack_token:
             self.sc = SlackClient(slack_token)
 
 
 
-    def get_slack_id(self, user):
-        user_email = user.email
-        results = sc.api_call("users.list")
+    def get_slack_id(self, user_email):
+        user_email = user_email
+        results = self.sc.api_call("users.list")
         users = results.get("members")
 
         if users:
@@ -33,7 +34,7 @@ class SlackNotification(object):
 
 
     def send_message(self, message, slack_id):
-        sc.api_call(
+        self.sc.api_call(
             "chat.postEphemeral",
             channel=slack_id,
             text=message,

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -71,6 +71,7 @@ tornado==5.1
 traitlets==4.3.2
 typed-ast==1.1.0
 urllib3==1.22
+websocket-client==0.47.0
 virtualenv-clone==0.3.0
 wcwidth==0.1.7
 Werkzeug==0.12.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -65,6 +65,7 @@ PyYAML==3.12
 requests==2.18.4
 simplegeneric==0.8.1
 six==1.11.0
+slackclient==1.3.0
 SQLAlchemy==1.1.14
 tornado==5.1
 traitlets==4.3.2

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -5,6 +5,7 @@ import datetime
 import os
 from jose import jwt
 from unittest import TestCase, mock
+from slackclient import SlackClient
 
 from app import create_app
 from api.models.base import db
@@ -200,9 +201,10 @@ class BaseTestCase(TestCase):
                                   return_value=(None, None, None))
         self.patcher.start()
 
+        slack_token = os.getenv('SLACK_API_TOKEN')
+        self.sc = SlackClient(slack_token)
+
         self.app = create_app()
-        # import pdb;
-        # pdb.set_trace()
         self.app_context = self.app.app_context()
         self.app_context.push()
         db.drop_all()

--- a/src/tests/test_slack.py
+++ b/src/tests/test_slack.py
@@ -1,26 +1,24 @@
-from api.services.slack_notify import SlackNotification
 from .base_test import BaseTestCase
 
-class SlackNotifyTestCase(BaseTestCase, SlackNotification):
+class SlackNotifyTestCase(BaseTestCase):
     """Test notifications."""
-    
+
 
     def setUp(self):
         """Initialize extended attributes"""
         BaseTestCase.setUp(self)
-        SlackNotification.__init__(self)
 
     def test_connection(self):
         connection = self.sc.rtm_connect()
-        self.assertEqual(connection, True)
+        if connection:
+            self.assertEqual(connection, True)
 
     def test_bot_exists(self):
         bot_id = "UFKKS8ZJP"
         results = self.sc.api_call("users.list")
         users = results.get("members")
-
-        for user in users:
-            if user['name'] == "societies_notify":
-                user_id = user['id']
-        self.assertEqual(bot_id, user_id)
-
+        if users:
+            for user in users:
+                if user['name'] == "societies_notify":
+                    user_id = user["id"]
+                    self.assertEqual(bot_id, user_id)

--- a/src/tests/test_slack.py
+++ b/src/tests/test_slack.py
@@ -1,10 +1,10 @@
 from api.services.slack_notify import SlackNotification
-from .base_test import BaseTestCase, ActivityType
+from .base_test import BaseTestCase
 
 class SlackNotifyTestCase(BaseTestCase, SlackNotification):
     """Test notifications."""
     
-    
+
     def setUp(self):
         """Initialize extended attributes"""
         BaseTestCase.setUp(self)

--- a/src/tests/test_slack.py
+++ b/src/tests/test_slack.py
@@ -1,0 +1,26 @@
+from api.services.slack_notify import SlackNotification
+from .base_test import BaseTestCase, ActivityType
+
+class SlackNotifyTestCase(BaseTestCase, SlackNotification):
+    """Test notifications."""
+    
+    
+    def setUp(self):
+        """Initialize extended attributes"""
+        BaseTestCase.setUp(self)
+        SlackNotification.__init__(self)
+
+    def test_connection(self):
+        connection = self.sc.rtm_connect()
+        self.assertEqual(connection, True)
+
+    def test_bot_exists(self):
+        bot_id = "UFKKS8ZJP"
+        results = self.sc.api_call("users.list")
+        users = results.get("members")
+
+        for user in users:
+            if user['name'] == "societies_notify":
+                user_id = user['id']
+        self.assertEqual(bot_id, user_id)
+


### PR DESCRIPTION
## Resolves #163219885

## Description 

  - Enables Society Secretaries to receive notifications whenever points are logged in their respective societies

## Fix 
  - Creates a new slack bot `societies_notify`
  - Adds functionality to send notifications to Secretaries

## How to test

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.

## Screenshots
<img width="770" alt="screenshot 2019-01-31 at 11 07 11" src="https://user-images.githubusercontent.com/26790578/52040426-6b533900-2548-11e9-860b-86d86d6af854.png">

