### PR TITLE
#163219972 Notify Success Ops when points are approved

### DIFF
--- a/src/api/endpoints/logged_activities/crud.py
+++ b/src/api/endpoints/logged_activities/crud.py
@@ -84,11 +84,7 @@ class LoggedActivitiesAPI(Resource, SlackNotification):
             #     users = filter(lambda x: x.society_id==society_id, self.all_users)
             users = User.query.filter_by(society_id=society_id).all()
             message = "New activities logged. Go to https://societies.andela.com to approve points"
-            for role in roles:
-                if role in users:
-                    user_email = role.email
-                    slack_id = SlackNotification.get_slack_id(self, user_email)
-                    SlackNotification.send_message(self, message, slack_id)
+            SlackNotification.send_notification(self, roles, users, message)
 
             return response_builder(dict(
                 data=single_logged_activity_schema.dump(logged_activity).data,

--- a/src/api/endpoints/logged_activities/secretary_review.py
+++ b/src/api/endpoints/logged_activities/secretary_review.py
@@ -19,15 +19,6 @@ class SecretaryReviewLoggedActivityAPI(Resource, SlackNotification):
         self.LoggedActivity = kwargs['LoggedActivity']
         SlackNotification.__init__(self)
 
-
-    # def send_notification(self, roles, users):
-    #     for role in roles:
-    #         if role in users:
-    #             user_email = role.email
-    #             print("the success ops member is: ", user_email)
-    #             slack_id = SlackNotification.get_slack_id(self, user_email)
-    #             SlackNotification.send_message(self, message, slack_id)
-
     @roles_required(['society secretary'])
     def put(self, logged_activity_id):
         """Put method on logged Activity resource."""
@@ -56,7 +47,7 @@ class SecretaryReviewLoggedActivityAPI(Resource, SlackNotification):
 
         roles = User.query.filter(User.roles.any(Role.name=="success ops")).all()
         users = User.query.all()
-        message = "New society points approved. Go to https://societies.andela.com to give redemption approval"
+        message = "New society points approved by society secretary. Go to https://societies.andela.com/u/verify-activities to review points" # noqa: E501
 
         logged_activity.status = payload.get('status')
         if logged_activity.status == "pending":

--- a/src/api/endpoints/logged_activities/secretary_review.py
+++ b/src/api/endpoints/logged_activities/secretary_review.py
@@ -19,6 +19,15 @@ class SecretaryReviewLoggedActivityAPI(Resource, SlackNotification):
         self.LoggedActivity = kwargs['LoggedActivity']
         SlackNotification.__init__(self)
 
+
+    # def send_notification(self, roles, users):
+    #     for role in roles:
+    #         if role in users:
+    #             user_email = role.email
+    #             print("the success ops member is: ", user_email)
+    #             slack_id = SlackNotification.get_slack_id(self, user_email)
+    #             SlackNotification.send_message(self, message, slack_id)
+
     @roles_required(['society secretary'])
     def put(self, logged_activity_id):
         """Put method on logged Activity resource."""
@@ -51,14 +60,8 @@ class SecretaryReviewLoggedActivityAPI(Resource, SlackNotification):
 
         logged_activity.status = payload.get('status')
         if logged_activity.status == "pending":
-            for role in roles:
-                if role in users:
-                    user_email = role.email
-                    print("the success ops member is: ", user_email)
-                    slack_id = SlackNotification.get_slack_id(self, user_email)
-                    SlackNotification.send_message(self, message, slack_id)
+            SlackNotification.send_notification(self, roles, users, message)
 
-        print("the logged status is: ", logged_activity.status)
         logged_activity.save()
 
         return response_builder(

--- a/src/api/endpoints/logged_activities/secretary_review.py
+++ b/src/api/endpoints/logged_activities/secretary_review.py
@@ -3,11 +3,13 @@ from flask import request, g
 
 from api.services.auth import token_required, roles_required
 from api.utils.helpers import response_builder
+from api.models import Role, User
+from api.services.slack_notify import SlackNotification
 
 from .marshmallow_schemas import single_logged_activity_schema
 
 
-class SecretaryReviewLoggedActivityAPI(Resource):
+class SecretaryReviewLoggedActivityAPI(Resource, SlackNotification):
     """Enable society secretary to verify logged activities."""
 
     decorators = [token_required]
@@ -15,6 +17,7 @@ class SecretaryReviewLoggedActivityAPI(Resource):
     def __init__(self, **kwargs):
         """Inject dependency for resource."""
         self.LoggedActivity = kwargs['LoggedActivity']
+        SlackNotification.__init__(self)
 
     @roles_required(['society secretary'])
     def put(self, logged_activity_id):
@@ -41,7 +44,21 @@ class SecretaryReviewLoggedActivityAPI(Resource):
         if not (payload.get('status') in ['pending', 'rejected']):
             return response_builder(dict(message='Invalid status value.'),
                                     400)
+
+        roles = User.query.filter(User.roles.any(Role.name=="success ops")).all()
+        users = User.query.all()
+        message = "New society points approved. Go to https://societies.andela.com to give redemption approval"
+
         logged_activity.status = payload.get('status')
+        if logged_activity.status == "pending":
+            for role in roles:
+                if role in users:
+                    user_email = role.email
+                    print("the success ops member is: ", user_email)
+                    slack_id = SlackNotification.get_slack_id(self, user_email)
+                    SlackNotification.send_message(self, message, slack_id)
+
+        print("the logged status is: ", logged_activity.status)
         logged_activity.save()
 
         return response_builder(

--- a/src/api/endpoints/logged_activities/secretary_review.py
+++ b/src/api/endpoints/logged_activities/secretary_review.py
@@ -47,7 +47,8 @@ class SecretaryReviewLoggedActivityAPI(Resource, SlackNotification):
 
         roles = User.query.filter(User.roles.any(Role.name=="success ops")).all()
         users = User.query.all()
-        message = "New society points approved by society secretary. Go to https://societies.andela.com/u/verify-activities to review points" # noqa: E501
+        message = f"The society secretary for {logged_activity.society.name} has approved an activity " + \
+                  f"worth {logged_activity.value} points. Go to https://societies.andela.com/u/verify-activities to approve or reject these points" # noqa: E501
 
         logged_activity.status = payload.get('status')
         if logged_activity.status == "pending":

--- a/src/api/services/slack_notify/notification.py
+++ b/src/api/services/slack_notify/notification.py
@@ -44,3 +44,10 @@ class SlackNotification(object):
             as_user=True,
             icon_emoji=':ninja:',
         )
+
+    def send_notification(self, roles, users, message):
+        for role in roles:
+            if role in users:
+                user_email = role.email
+                slack_id = self.get_slack_id(user_email)
+                self.send_message(message, slack_id)


### PR DESCRIPTION
## Resolves #163219972

## Description

  - Ensures Success Ops users receive notifications whenever Society Secretaries approve logged points.

## Fix 

  - Adds the `send notification to success ops users` functionality
 
## How to test

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.

## Screenshots

<img width="883" alt="screenshot 2019-02-11 at 16 59 41" src="https://user-images.githubusercontent.com/26790578/52567925-7e0a1f80-2e1e-11e9-925d-c361ea32b3a6.png">


