### PR TITLE
#163220049 Send notification to society president once a redemption request is rejected

### DIFF
--- a/src/api/endpoints/redemption_requests/redemption_numeration.py
+++ b/src/api/endpoints/redemption_requests/redemption_numeration.py
@@ -12,7 +12,6 @@ from api.services.slack_notify import SlackNotification
 # import from this package
 from .helpers import serialize_redmp
 from .marshmallow_schemas import edit_redemption_request_schema
-from api.models import Role, User
 
 
 class RedemptionRequestNumeration(Resource, SlackNotification):


### PR DESCRIPTION
## Resolves #163220049

## Description

  - New feature to send a slack notification to a Society President in case a redemption request is rejected.

## Fix

  - Add functionality that depends on slack to send the notification

## How to test

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.

## Screenshots

<img width="699" alt="screen shot 2019-02-21 at 11 58 17" src="https://user-images.githubusercontent.com/26790578/53156913-6f1b2e00-35d1-11e9-9a10-89fd3449dcd2.png">

