### PR TITLE
#164100584 implement getting fellow's D-level

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 
 [dev-packages]
+pylint = "*"
 
 [requires]
 python_version = "3.7"

--- a/src/api/endpoints/logged_activities/user_logged_activities.py
+++ b/src/api/endpoints/logged_activities/user_logged_activities.py
@@ -1,7 +1,8 @@
 from flask_restful import Resource
+from flask import g
 
 from api.services.auth import token_required
-from api.utils.helpers import response_builder
+from api.utils.helpers import response_builder, find_d_level
 
 from .marshmallow_schemas import user_logged_activities_schema
 from .models import db
@@ -36,13 +37,18 @@ class UserLoggedActivitiesAPI(Resource):
             self.LoggedActivity.status == 'approved'
         ).scalar()
 
-        return response_builder(dict(
-            data=user_logged_activities_schema.dump(
+        data=user_logged_activities_schema.dump(
                 user_logged_activities
-            ).data,
+            ).data
+
+        # Fetch D-level info
+        user_level = find_d_level(g.current_user_token, user_id)
+        return response_builder(dict(
+            data=data,
             society=user.society.name if user.society else None,
             societyId=user.society.uuid if user.society else None,
             activitiesLogged=len(user_logged_activities),
+            level=user_level,
             pointsEarned=points_earned if points_earned else 0,
             message=message
         ), 200)

--- a/src/api/utils/helpers.py
+++ b/src/api/utils/helpers.py
@@ -1,5 +1,6 @@
 """Contain utility functions and constants."""
 
+import requests, os
 from collections import namedtuple
 from flask import current_app, jsonify, request, url_for
 
@@ -113,3 +114,24 @@ def response_builder(data, status_code=200):
     response = jsonify(data)
     response.status_code = status_code
     return response
+
+def find_d_level(token, user_id):
+    """ Returns The D-level information
+
+        token(str) - token supplied by the user
+        user_id(UUID) - the user Id
+        returns a dictonary object containing the d level
+    """
+    url=os.environ.get('ANDELA_API_URL')
+    Bearer = 'Bearer '
+    headers = {'Authorization': Bearer + token}
+
+    try:
+        api_response = requests.get(url + f"users/{user_id}", headers=headers).json().get('level')
+        return api_response
+    except requests.exceptions.ConnectionError:
+        response = jsonify({"Error": "Network Error."})
+        response.status_code = 503
+        return response
+    except Exception:
+        return None

--- a/src/tests/test_logged_activities.py
+++ b/src/tests/test_logged_activities.py
@@ -326,6 +326,25 @@ class LogActivityTestCase(BaseTestCase):
             json.loads(response.get_data(as_text=True))['message'],
             'You\'re late. That activity happened more than 30 days ago'
         )
+    def test_fellow_level_information_is_present(self):
+        """
+        Test fellow D-level information is fetched in th user's logged activities.
+
+        When this is done by an authenticated user it should not fail.
+        """
+        test_user_id = self.test_user.uuid
+        response = self.client.get(
+            f'/api/v1/users/{test_user_id}/logged-activities',
+            headers=self.header
+        )
+
+        # test that request was successful
+        self.assertEqual(response.status_code, 200)
+
+        response_content = json.loads(response.get_data(as_text=True))
+        # test that response data matches database query results
+        self.assertEqual(len(response_content), 7)
+        self.assertIn('level', response_content)
 
 
 class EditLoggedActivityTestCase(BaseTestCase):


### PR DESCRIPTION
## Resolves #164100584

## Description (what problem you're fixing)

  - Retrieve the D-level of a fellow from the andela API 

## Fix (what you did to fix it)

  - Add the d-level information to the response object in under the user logged activities
  

## How to test (describe how to test your PR)

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.

## Screen Shot
<img width="706" alt="Screenshot 2019-03-12 at 13 45 05" src="https://user-images.githubusercontent.com/19773670/54194490-7006f780-44cd-11e9-953e-e98b3e98d0e3.png">
