### PR TITLE
#163219991 Notify Finance via Slack whenever Society redemptions are approved

### DIFF
--- a/src/api/endpoints/redemption_requests/redemption_numeration.py
+++ b/src/api/endpoints/redemption_requests/redemption_numeration.py
@@ -86,7 +86,7 @@ class RedemptionRequestNumeration(Resource, SlackNotification):
                     SlackNotification.send_message(self, message, slack_id)
                 else:
                     pass
-   
+
             # Get the relevant Finance Center to respond on RedemptionRequest
             center_emails = {"kampala": ".finance@andela.com"}
             finance_email = redemp_request.center.name.lower() + \


### PR DESCRIPTION
## Resolves #163219991

## Description

  - Ensure Finance users are notified through slack whenever society redemptions are approved.

## Fix 

  - Adds a functionality that makes use of Slack integrations to implement the feature.
  -

## How to test

- Clone the repository, install docker, run `make test` within the repository.
- Trigger a build on CircleCI.

##Screenshots

<img width="874" alt="Screenshot 2019-03-22 at 12 36 53" src="https://user-images.githubusercontent.com/26790578/54814603-24103b80-4ca1-11e9-83e3-9de9ae4051b0.png">

